### PR TITLE
fix inconsistent version

### DIFF
--- a/src/dng-dnm.cc
+++ b/src/dng-dnm.cc
@@ -48,7 +48,7 @@ using namespace RBD_LIBRARIES;
 #endif
 
 #ifndef VERSION
-#define VERSION "DeNovoGear 0.5.4"
+#define VERSION "DeNovoGear 1.0"
 #endif
 
 int RD_cutoff = 10; // cutoff for the read depth filter

--- a/src/dng.sh
+++ b/src/dng.sh
@@ -17,7 +17,7 @@
 #
 
 # version info
-version_num=0.1
+version_num=1.0
 
 # set default libexec location
 # under certail conditions this may fail to work, so an installer should set


### PR DESCRIPTION
There are a couple of places in the code where the version is being set and this commit makes sure they print out the right version(currently ver 1.0). It would be nice to print out the version each time DNG is run just as a sanity check for the users, maybe we just want to eliminate version variables in the CPP code and print it out in the bash wrapper script.
