### PR TITLE
Using bash instead of sh in dng.sh

### DIFF
--- a/src/dng.sh
+++ b/src/dng.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Copyright (C) 2013-2014 Reed A. Cartwright <reed@cartwrig.ht>
 #


### PR DESCRIPTION
This change is necessary to use `function` on my Linux system.