### PR TITLE
Vcfinput

### DIFF
--- a/src/include/dng/hts/bcf.h
+++ b/src/include/dng/hts/bcf.h
@@ -120,6 +120,14 @@ public:
 		return bcf_hdr_add_sample(hdr, sample);
 	}
 
+	/** Add a "#contig=" metadata entry to the VCF header. */
+	int AddContig(const char *contigid) {
+	        if(contigid == nullptr)
+		        return -1;
+	        std::string conv = std::string("##contig=<ID=") + contigid + ",length=1>";
+	        return bcf_hdr_append(hdr, conv.c_str());
+	}
+
 	/** Creates the header field. Call only after adding all the sample fields */
 	int WriteHeader() {
 		bcf_hdr_add_sample(hdr, nullptr); // libhts requires NULL sample before it will write out all the other samples
@@ -139,14 +147,17 @@ public:
 			return; // should display some error?
 
 		std::string chrom_s(chrom);
+		/*
 		// TODO: Cache last contig_id, since it is likely to be the same??
 		// TODO: Preprocess the "##congig strings based on bam contigs???"
 		if(contig_ids.find(chrom_s) == contig_ids.end()) {
 			// there needs to be a matching contig id in the header otherwise bcf_write1() will fault [tracked issue to vcf.cc vcf_format()]
 			std::string conv = std::string("##contig=<ID=") + chrom_s + ",length=1>";
 			bcf_hdr_append(hdr, conv.c_str());
+			bcf_hdr_write(handle(), hdr);
 			contig_ids.insert(chrom_s);
 		}
+		*/
 		rec->rid = bcf_hdr_name2id(hdr, chrom);
 
 		// POS

--- a/src/include/dng/read_group.h
+++ b/src/include/dng/read_group.h
@@ -237,7 +237,7 @@ void ReadGroups::Parse(InFFile *fname)
 			           // TODO: Currently assuming there is only one genome per sample and not a mixture. If needed either
 			           // check there are no ';' or that "Mixture=1."
 			           val.sample = std::string(kv_pairs->vals[a]);
-				   std::cout << kv_pairs->keys[a] <<  ">" << val.sample << std::endl;
+				  
 			    }
 		     }
 	      }

--- a/src/include/dng/read_group.h
+++ b/src/include/dng/read_group.h
@@ -201,46 +201,65 @@ void ReadGroups::Parse(InFiles &range) {
 	// connect groups to libraries and samples	
 	library_from_id_.resize(groups_.size());
 	for(auto &a : data_) {
-		library_from_id_[rg::index(groups_,a.id)] = rg::index(libraries_,a.library);
+	       	library_from_id_[rg::index(groups_,a.id)] = rg::index(libraries_,a.library);
 
 	}
 }
 
+/**
+ * Parses an VCF file into read groups, sample names and libraries
+ * fname - file path and name string for input vcf file
+ */
 template<typename InFFile>
 void ReadGroups::Parse(InFFile *fname)
 {
-  std::cout << "Parse VCF file: " << fname << std::endl;
 	htsFile *fp = hts_open(fname, "r");
 	bcf_hdr_t *hdr = bcf_hdr_read(fp);
 	
 	// Read through samples from the header
 	int n_samples = bcf_hdr_nsamples(hdr);
-	std::cout << n_samples << std::endl;
-	char **samples = hdr->samples;
+	char **gt_samples = hdr->samples;
 	for(size_t a = 0; a < n_samples; a++) {
-	  //std::cout << "here" << std::endl;
-	  //std::cout << std::string(samples[a]) << std::endl;
 	      ReadGroup val{std::to_string(a)}; // Don't know what else to use for "@RG ID"?
-	      val.sample = std::string(samples[a]);
-	      val.library = val.sample; // May have to change in the future? 
+
+	      // Each genotype(i.e sample) column in the VCF file represents an unique library. If multiple libraries comes from
+	      // the same individual, then it must be specified in the "##SAMPLE=<ID=lib,Genomes=indv>" field in the header.
+	      // Otherwise we have to assume each library comes from a unique individual
+	      val.library = std::string(gt_samples[a]);
+	      val.sample = std::string(gt_samples[a]); // Default value
+     
+
+	      // Check "##SAMPLE" field for ID=val.library. If header field exists then function will return all key-value pairs
+	      bcf_hrec_t *kv_pairs = bcf_hdr_get_hrec(hdr, BCF_HL_STR, "ID", val.library.c_str(), "SAMPLE");
+	      if(kv_pairs != NULL) {
+	             for(int a = 0; a < kv_pairs->nkeys; a++) {
+		            if(kv_pairs->keys[a] != NULL && strcmp(kv_pairs->keys[a], "Genomes") == 0) { // May need to convert to upper, Vcf4.2 standard unclear?
+			           // TODO: Currently assuming there is only one genome per sample and not a mixture. If needed either
+			           // check there are no ';' or that "Mixture=1."
+			           val.sample = std::string(kv_pairs->vals[a]);
+				   std::cout << kv_pairs->keys[a] <<  ">" << val.sample << std::endl;
+			    }
+		     }
+	      }
+						   
 	      data_.insert(std::move(val));
 	}
 
+	// TODO: combine this code and above into inline.
 	// construct data vectors
 	groups_.reserve(data_.size());
 	libraries_.reserve(data_.size());
 	samples_.reserve(data_.size());
 	for(auto &a : data_) {
-	  groups_.insert(a.id);
-	  libraries_.insert(a.library);
-	  samples_.insert(a.sample);
+	       groups_.insert(a.id);
+	       libraries_.insert(a.library);
+	       samples_.insert(a.sample);
 	}
 
 	// connect groups to libraries and samples
 	library_from_id_.resize(groups_.size());
 	for(auto &a : data_) {
-	  library_from_id_[rg::index(groups_,a.id)] = rg::index(libraries_,a.library);
-
+	       library_from_id_[rg::index(groups_,a.id)] = rg::index(libraries_,a.library);
 	}
 }
  

--- a/src/include/dng/read_group.h
+++ b/src/include/dng/read_group.h
@@ -209,17 +209,20 @@ void ReadGroups::Parse(InFiles &range) {
 template<typename InFFile>
 void ReadGroups::Parse(InFFile *fname)
 {
-  
+  std::cout << "Parse VCF file: " << fname << std::endl;
 	htsFile *fp = hts_open(fname, "r");
 	bcf_hdr_t *hdr = bcf_hdr_read(fp);
 	
 	// Read through samples from the header
 	int n_samples = bcf_hdr_nsamples(hdr);
+	std::cout << n_samples << std::endl;
 	char **samples = hdr->samples;
-	for(size_t a; a < n_samples; a++) {
+	for(size_t a = 0; a < n_samples; a++) {
+	  //std::cout << "here" << std::endl;
+	  //std::cout << std::string(samples[a]) << std::endl;
 	      ReadGroup val{std::to_string(a)}; // Don't know what else to use for "@RG ID"?
 	      val.sample = std::string(samples[a]);
-	      val.library = val.id + "\t" + val.sample; // If we don't have to worry about collusions just use library=sample?
+	      val.library = val.sample; // May have to change in the future? 
 	      data_.insert(std::move(val));
 	}
 

--- a/src/include/dng/read_group.h
+++ b/src/include/dng/read_group.h
@@ -35,8 +35,10 @@
 #include <boost/multi_index/ordered_index.hpp>
 #include <boost/multi_index/member.hpp>
 
-
 #include <unordered_set>
+
+#include <htslib/vcf.h>
+
 
 namespace dng {
 
@@ -73,21 +75,39 @@ namespace detail {
 		>> DataBase;
 }
 
+ 
 class ReadGroups {
 public:
 	typedef boost::container::flat_set<std::string> StrSet;
 	typedef detail::rg_t ReadGroup;
 	typedef detail::DataBase DataBase;
 
-	ReadGroups() { }
+	//ReadGroups() { }
 	
-	template<typename InFiles>
-	ReadGroups(InFiles &range) {
-		Parse(range);
-	}
+	///template<typename InFiles>
+	//ReadGroups(InFiles &range) {
+	//	Parse(range);
+	//}
 
+	// Parse a single vcf file into read groups
+	//void ParseVCF(const char *fname);
+
+
+	
+	// Parse a list of BAM/SAM files into readgroups
 	template<typename InFiles>
 	void Parse(InFiles &range);
+
+	template<typename InFile>
+	void Parse(InFile *fname);
+	
+	/*
+	template<>
+	  void Parse<const char>(const char *fname)
+	  {
+
+	  }
+	*/
 	
 	inline const StrSet& groups() const { return groups_; }
 	inline const StrSet& libraries() const { return libraries_; }
@@ -115,6 +135,7 @@ inline std::size_t index(const ReadGroups::StrSet& set, const std::string& query
 	return (it != set.end()) ? static_cast<std::size_t>(it-set.begin()) : -1;
 }
 }
+
 
 template<typename InFiles>
 void ReadGroups::Parse(InFiles &range) {
@@ -197,6 +218,12 @@ void ReadGroups::Parse(InFiles &range) {
 	}
 }
 
+template<typename InFFile>
+void ReadGroups::Parse(InFFile *fname)
+{
+
+}
+ 
 }
 
 #endif

--- a/src/include/dng/read_group.h
+++ b/src/include/dng/read_group.h
@@ -239,7 +239,6 @@ void ReadGroups::Parse(InFFile *fname)
 	  library_from_id_[rg::index(groups_,a.id)] = rg::index(libraries_,a.library);
 
 	}
-
 }
  
 }

--- a/src/include/dng/task/call.xmh
+++ b/src/include/dng/task/call.xmh
@@ -43,6 +43,7 @@ XM((ref)(weight), (R), "weight given to reference base for population prior", do
 XM((sam)(files), (s), "file containing a list of input filenames, one per line", std::string, "")
 XM((theta), , "the population diversity", double, DL(0.001, "0.001"))
 XM((output), (o),"Output VCF/BCF file", std::string, "-")
+XM((vcfin), (i), "Use a VCF file as input instead of BAM", std::string, "")
 
 /***************************************************************************
  *    cleanup                                                              *

--- a/src/include/dng/task/call.xmh
+++ b/src/include/dng/task/call.xmh
@@ -43,7 +43,7 @@ XM((ref)(weight), (R), "weight given to reference base for population prior", do
 XM((sam)(files), (s), "file containing a list of input filenames, one per line", std::string, "")
 XM((theta), , "the population diversity", double, DL(0.001, "0.001"))
 XM((output), (o),"Output VCF/BCF file", std::string, "-")
-XM((vcfin), (i), "Use a VCF file as input instead of BAM", std::string, "")
+XM((vcf)(input), (v), "Input file is a VCF file instead of default BAM", bool, false)
 
 /***************************************************************************
  *    cleanup                                                              *

--- a/src/include/dng/vcfpileup.h
+++ b/src/include/dng/vcfpileup.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2014 Reed A. Cartwright
+ * Authors:  Reed A. Cartwright <reed@cartwrig.ht>
+ *
+ * This file is part of DeNovoGear.
+ *
+ * DeNovoGear is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+#ifndef DNG_VCFPILEUP_H
+#define DNG_VCFPILEUP_H
+
+#include <vector>
+#include <limits>
+#include <unordered_map>
+
+#include <dng/hts/bam.h>
+#include <htslib/faidx.h>
+
+#include <boost/range/begin.hpp>
+#include <boost/range/end.hpp>
+#include <boost/range/size.hpp>
+#include <boost/range/metafunctions.hpp>
+#include <boost/range/algorithm/lower_bound.hpp>
+#include <boost/range/algorithm/sort.hpp>
+
+#include <dng/pool.h>
+#include <dng/fileio.h>
+#include <dng/cigar.h>
+#include <dng/read_group.h>
+
+namespace dng { namespace pileup { namespace vcf {
+
+
+class VCFPileup {
+public:
+        typedef NodeList list_type;
+	typedef Node node_type;
+	typedef detail::NodePool pool_type;
+
+	typedef std::vector<list_type> data_type;
+	typedef void (callback_type)(const data_type&, uint64_t);
+
+	template<typename InFiles, typename Func>
+	void operator()(InFiles &range, Func func);
+
+	template<typename RG>
+	MPileup(const RG& rg) : pool_(4048), read_groups_(rg) {
+	        boost::sort(read_groups_);
+	}
+
+	
+
+private:
+	char *fname = 0;
+	bool iscompressed = false;
+};
+
+template<typename InFile, typename Func>
+void VCFPileup::operator()(InFile fname, Func func) {
+        // TODO: If using multiple input vcf files then we may require scanners to search each file for the same position
+
+        // type erase callback function
+        function<callback_type> call_back(func);
+   
+        // Open the VCF/BCF file
+        htsFile *fp = hts_open(fname, "r");
+	bcf_hdr_t *hdr = bcf_hdr_read(fp);
+	bcf1_t *rec = bcf_init1();
+
+	while(bcf_read1(fp, hdr, rec) >= 0) {
+	  // check that the current record is for an SNP and not an Indel, MNP, or something else
+	  if(bcf_get_variant_types(rec) != VCF_SNP)
+	    continue;
+
+	  // TODO: Check the QUAL field or PL,PP genotype fields
+
+	  // execute func
+	  call_back(rec, hdr);
+	}
+}
+	  
+}}} //namespace dng::pileup::vcf
+
+#endif //DNG_VCFPILEUP_H
+

--- a/src/include/dng/vcfpileup.h
+++ b/src/include/dng/vcfpileup.h
@@ -45,34 +45,26 @@ namespace dng { namespace pileup { namespace vcf {
 
 class VCFPileup {
 public:
-        typedef NodeList list_type;
-	typedef Node node_type;
-	typedef detail::NodePool pool_type;
-
-	typedef std::vector<list_type> data_type;
-	typedef void (callback_type)(const data_type&, uint64_t);
-
-	template<typename InFiles, typename Func>
-	void operator()(InFiles &range, Func func);
-
-	template<typename RG>
-	MPileup(const RG& rg) : pool_(4048), read_groups_(rg) {
-	        boost::sort(read_groups_);
-	}
-
+	typedef void (callback_type)(bcf_hdr_t*, bcf1_t*);
 	
+	VCFPileup() {
+	     // Not yet sure if ReadGroups should be passed in
+	}
+	
+	template<typename Func>
+	void operator()(const char *fname, Func func);
 
 private:
-	char *fname = 0;
-	bool iscompressed = false;
+	//char *fname = 0;
+	//bool iscompressed = false;
 };
 
-template<typename InFile, typename Func>
-void VCFPileup::operator()(InFile fname, Func func) {
-        // TODO: If using multiple input vcf files then we may require scanners to search each file for the same position
+template<typename Func>
+void VCFPileup::operator()(const char *fname, Func func) {
+        // TODO? If using multiple input vcf files then we may require scanners to search each file for the same position
 
         // type erase callback function
-        function<callback_type> call_back(func);
+        std::function<callback_type> call_back(func);
    
         // Open the VCF/BCF file
         htsFile *fp = hts_open(fname, "r");
@@ -84,10 +76,10 @@ void VCFPileup::operator()(InFile fname, Func func) {
 	  if(bcf_get_variant_types(rec) != VCF_SNP)
 	    continue;
 
-	  // TODO: Check the QUAL field or PL,PP genotype fields
+	  // TODO? Check the QUAL field or PL,PP genotype fields
 
 	  // execute func
-	  call_back(rec, hdr);
+	  call_back(hdr, rec);
 	}
 }
 	  

--- a/src/lib/call.cc
+++ b/src/lib/call.cc
@@ -376,7 +376,7 @@ int Call::operator()(Call::argument_type &arg) {
 	      }
 	      cout << endl;
 #else
-	      vcf_add_record(vcfout, target_name, position+1, ref_base, d, p, read_depths);
+	      vcf_add_record(vcfout, target_name, position, ref_base, d, p, read_depths);
 #endif
 	      return;
 	};


### PR DESCRIPTION
vcfpileup.h has a new class that is analogous to MPileup but only for VCF files. ReadGroups has a new Parse function for vcf file. The old parse function is the same. Most of the remaining changes are in call.cc, which uses a -v flag to indicate that the input should be a single vcf instead of a list of bam files.
