### PR TITLE
Feature/read groups

### DIFF
--- a/src/include/dng/read_group.h
+++ b/src/include/dng/read_group.h
@@ -161,7 +161,7 @@ inline void ReadGroups::ReloadData() {
     // connect groups to libraries and samples
     library_from_id_.resize(groups_.size());
     for(auto && a : data_) {
-    	library_from_id_[rg::index(groups_, a.id)] = rg::index(libraries_, a.library);
+        library_from_id_[rg::index(groups_, a.id)] = rg::index(libraries_, a.library);
 
     }
 }
@@ -169,8 +169,8 @@ inline void ReadGroups::ReloadData() {
 
 template<typename InFiles>
 void ReadGroups::ParseHeaderText(InFiles &range, const std::string &lbtag) {
-	// Get tag to identify libraries, LB by default.
-	const std::string &lbtag_str = (lbtag.empty() ? "LB" : lbtag);
+    // Get tag to identify libraries, LB by default.
+    const std::string &lbtag_str = (lbtag.empty() ? "LB" : lbtag);
 
     // iterate through each file in the range
     for(auto && f : range) {
@@ -223,7 +223,7 @@ void ReadGroups::ParseHeaderText(InFiles &range, const std::string &lbtag) {
 
             // sample tag
             if((it = tags.find("SM")) != tags.end()) {
-            	val.sample = it->second;//std::move(it->second);
+                val.sample = it->second;//std::move(it->second);
             } else {
                 val.sample = val.id;
             }
@@ -231,16 +231,17 @@ void ReadGroups::ParseHeaderText(InFiles &range, const std::string &lbtag) {
             // library tag
             it = tags.find(lbtag_str);
             if(it == tags.end()) {
-            	// Will throw an error if any @RG header line is missing tag.
-                throw std::runtime_error("@RG header for '" + std::string(f.name()) + "' is missing " + lbtag_str + " tag." +
-                		"  Please fix or use option \'--lbtag\' to use another tag to identify libraries.");
+                // Will throw an error if any @RG header line is missing tag.
+                throw std::runtime_error("@RG header for '" + std::string(
+                                             f.name()) + "' is missing " + lbtag_str + " tag." +
+                                         "  Please fix or use option \'--lbtag\' to use another tag to identify libraries.");
             } else {
-            	// Unless using SM tag to group different libraries, prepend SM tag for readability
-            	if(lbtag_str == "SM") {
-            		val.library = it->second;
-            	} else {
-            		val.library = val.sample + "-" + it->second;
-            	}
+                // Unless using SM tag to group different libraries, prepend SM tag for readability
+                if(lbtag_str == "SM") {
+                    val.library = it->second;
+                } else {
+                    val.library = val.sample + "-" + it->second;
+                }
             }
 
             data_.insert(std::move(val));

--- a/src/include/dng/read_group.h
+++ b/src/include/dng/read_group.h
@@ -85,7 +85,7 @@ public:
 
     // Parse a list of BAM/SAM files into read groups
     template<typename InFiles>
-    void ParseHeaderText(InFiles &range);
+    void ParseHeaderText(InFiles &range, const std::string &lbtag = "LB");
 
     // Parse a VCF file
     template<typename InFiles>
@@ -161,13 +161,17 @@ inline void ReadGroups::ReloadData() {
     // connect groups to libraries and samples
     library_from_id_.resize(groups_.size());
     for(auto && a : data_) {
-        library_from_id_[rg::index(groups_, a.id)] = rg::index(libraries_, a.library);
+    	library_from_id_[rg::index(groups_, a.id)] = rg::index(libraries_, a.library);
 
     }
 }
 
+
 template<typename InFiles>
-void ReadGroups::ParseHeaderText(InFiles &range) {
+void ReadGroups::ParseHeaderText(InFiles &range, const std::string &lbtag) {
+	// Get tag to identify libraries, LB by default.
+	const std::string &lbtag_str = (lbtag.empty() ? "LB" : lbtag);
+
     // iterate through each file in the range
     for(auto && f : range) {
         // get header text and continue on failure
@@ -179,6 +183,7 @@ void ReadGroups::ParseHeaderText(InFiles &range) {
         // enumerate over read groups
         for(text = strstr(text, "@RG\t"); text != nullptr;
                 text = strstr(text, "@RG\t")) {
+
             text += 4; // skip @RG\t
             // parse the @RG line as tab-separated key:value pairs
             // use a map to separate the parsing logic from the rg_t struct
@@ -218,21 +223,26 @@ void ReadGroups::ParseHeaderText(InFiles &range) {
 
             // sample tag
             if((it = tags.find("SM")) != tags.end()) {
-                val.sample = std::move(it->second);
+            	val.sample = it->second;//std::move(it->second);
             } else {
                 val.sample = val.id;
             }
+
             // library tag
-            it = tags.find("LB");
-            val.library = val.sample;
-            if(it != tags.end()) {
-                // Prevent collision of LB tags from different samples by prepending sample tag
-                if(val.library != it->second) {
-                    val.library += '-' + it->second;
-                }
-            } else if(val.library != val.id) {
-                val.library += '-' + val.id;
+            it = tags.find(lbtag_str);
+            if(it == tags.end()) {
+            	// Will throw an error if any @RG header line is missing tag.
+                throw std::runtime_error("@RG header for '" + std::string(f.name()) + "' is missing " + lbtag_str + " tag." +
+                		"  Please fix or use option \'--lbtag\' to use another tag to identify libraries.");
+            } else {
+            	// Unless using SM tag to group different libraries, prepend SM tag for readability
+            	if(lbtag_str == "SM") {
+            		val.library = it->second;
+            	} else {
+            		val.library = val.sample + "-" + it->second;
+            	}
             }
+
             data_.insert(std::move(val));
         }
     }

--- a/src/include/dng/task/call.xmh
+++ b/src/include/dng/task/call.xmh
@@ -50,7 +50,8 @@ XM((sam)(files), (s), "file containing a list of input filenames, one per line",
    std::string, "")
 XM((theta), , "the population diversity", double, DL(0.001, "0.001"))
 XM((output), (o), "Output VCF/BCF file", std::string, "-")
-XM((lbtag), , "SAM read group header tag to uniquely identify libraries.", std::string, "LB")
+XM((lbtag), , "SAM read group header tag to uniquely identify libraries.",
+   std::string, "LB")
 
 /***************************************************************************
  *    cleanup                                                              *

--- a/src/include/dng/task/call.xmh
+++ b/src/include/dng/task/call.xmh
@@ -50,6 +50,7 @@ XM((sam)(files), (s), "file containing a list of input filenames, one per line",
    std::string, "")
 XM((theta), , "the population diversity", double, DL(0.001, "0.001"))
 XM((output), (o), "Output VCF/BCF file", std::string, "-")
+XM((lbtag), , "SAM read group header tag to uniquely identify libraries.", std::string, "LB")
 
 /***************************************************************************
  *    cleanup                                                              *

--- a/src/include/dng/task/call.xmh
+++ b/src/include/dng/task/call.xmh
@@ -49,8 +49,8 @@ XM((ref)(weight), (R), "weight given to reference base for population prior",
 XM((sam)(files), (s), "file containing a list of input filenames, one per line",
    std::string, "")
 XM((theta), , "the population diversity", double, DL(0.001, "0.001"))
-XM((output), (o), "Output VCF/BCF file", std::string, "-")
-XM((rgtag), , "SAM read group header tag to uniquely identify libraries.",
+XM((output), (o), "output VCF/BCF file", std::string, "-")
+XM((rgtag), , "combine read groups using @RG tags, e.g. ID, SM, LB, or DS.",
    std::string, "LB")
 
 /***************************************************************************

--- a/src/include/dng/task/call.xmh
+++ b/src/include/dng/task/call.xmh
@@ -50,7 +50,7 @@ XM((sam)(files), (s), "file containing a list of input filenames, one per line",
    std::string, "")
 XM((theta), , "the population diversity", double, DL(0.001, "0.001"))
 XM((output), (o), "Output VCF/BCF file", std::string, "-")
-XM((lbtag), , "SAM read group header tag to uniquely identify libraries.",
+XM((rgtag), , "SAM read group header tag to uniquely identify libraries.",
    std::string, "LB")
 
 /***************************************************************************

--- a/src/lib/call.cc
+++ b/src/lib/call.cc
@@ -380,7 +380,7 @@ int Call::operator()(Call::argument_type &arg) {
         }
 
         // Add each genotype/sample column
-        rgs.ParseHeaderText(bamdata);
+        rgs.ParseHeaderText(bamdata, arg.lbtag);
     } else if(cat == variant_data) {
         bcfdata.emplace_back(std::move(indata[0]));
         // Read header from first file

--- a/src/lib/call.cc
+++ b/src/lib/call.cc
@@ -380,7 +380,7 @@ int Call::operator()(Call::argument_type &arg) {
         }
 
         // Add each genotype/sample column
-        rgs.ParseHeaderText(bamdata, arg.lbtag);
+        rgs.ParseHeaderText(bamdata, arg.rgtag);
     } else if(cat == variant_data) {
         bcfdata.emplace_back(std::move(indata[0]));
         // Read header from first file

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -194,16 +194,16 @@ SET_TESTS_PROPERTIES(Phaser_Sample PROPERTIES
 
 ##### Issue 51 (and 52) - Test cases for various library identifiers (by LB, SM, and RG). ####
 # Only check the headers. Data will be different (and possibly meaningless) depending on how read-group libraries are grouped together 
-
-ADD_TEST(CALL_Sample5.3_BAM_LB_TAG ${DNG_CALL_EXE} -f ${TEST_DATA_DIR}/sample_5_3/sample-5.3_ref.fasta.gz -p ${TEST_DATA_DIR}/sample_5_3/ceu.ped -m 0.001 --lbtag "LB" ${TEST_DATA_DIR}/sample_5_3/test1.bam)
+# TODO: Incorporate test into the test_read_groups.cc unit-tests.
+ADD_TEST(CALL_Sample5.3_BAM_LB_TAG ${DNG_CALL_EXE} -f ${TEST_DATA_DIR}/sample_5_3/sample-5.3_ref.fasta.gz -p ${TEST_DATA_DIR}/sample_5_3/ceu.ped -m 0.001 --rgtag "LB" ${TEST_DATA_DIR}/sample_5_3/test1.bam)
 SET_TESTS_PROPERTIES(CALL_Sample5.3_BAM_LB_TAG PROPERTIES 
 	PASS_REGULAR_EXPRESSION "FORMAT\tGL-1\tGL-2\tLB-NA12878-Solexa-135852\tLB-NA12891-Solexa-135851\tLB-NA12892-Solexa-135853"
 )
-ADD_TEST(CALL_Sample5.3_BAM_SM_TAG ${DNG_CALL_EXE} -f ${TEST_DATA_DIR}/sample_5_3/sample-5.3_ref.fasta.gz -p ${TEST_DATA_DIR}/sample_5_3/ceu.ped -m 0.001 --lbtag "SM" ${TEST_DATA_DIR}/sample_5_3/test1.bam)
+ADD_TEST(CALL_Sample5.3_BAM_SM_TAG ${DNG_CALL_EXE} -f ${TEST_DATA_DIR}/sample_5_3/sample-5.3_ref.fasta.gz -p ${TEST_DATA_DIR}/sample_5_3/ceu.ped -m 0.001 --rgtag "SM" ${TEST_DATA_DIR}/sample_5_3/test1.bam)
 SET_TESTS_PROPERTIES(CALL_Sample5.3_BAM_SM_TAG PROPERTIES 
 	PASS_REGULAR_EXPRESSION "FORMAT\tGL-1\tGL-2\tLB-NA12878\tLB-NA12891\tLB-NA12892"
 )
-ADD_TEST(CALL_Sample5.3_BAM_ID_TAG ${DNG_CALL_EXE} -f ${TEST_DATA_DIR}/sample_5_3/sample-5.3_ref.fasta.gz -p ${TEST_DATA_DIR}/sample_5_3/ceu.ped -m 0.001 --lbtag "ID" ${TEST_DATA_DIR}/sample_5_3/test1.bam)
+ADD_TEST(CALL_Sample5.3_BAM_ID_TAG ${DNG_CALL_EXE} -f ${TEST_DATA_DIR}/sample_5_3/sample-5.3_ref.fasta.gz -p ${TEST_DATA_DIR}/sample_5_3/ceu.ped -m 0.001 --rgtag "ID" ${TEST_DATA_DIR}/sample_5_3/test1.bam)
 SET_TESTS_PROPERTIES(CALL_Sample5.3_BAM_ID_TAG PROPERTIES 
 	PASS_REGULAR_EXPRESSION "FORMAT\tGL-1\tGL-2\tSM-NA12891\tSM-NA12892\tSM-NA12878\tLB-NA12878-H06HD.1\tLB-NA12878-H06HD.2\tLB-NA12878-H06JU.1\tLB-NA12891-H03N7.1\tLB-NA12891-H03N7.2\tLB-NA12891-H05F1.2\tLB-NA12892-H06JH.1\tLB-NA12892-H06JH.2\tLB-NA12892-H06JU.2"
 )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -191,3 +191,20 @@ SET_TESTS_PROPERTIES(Phaser_Sample PROPERTIES
   PASS_REGULAR_EXPRESSION "HAP POS 182974760 p1: GT p2: CA"
   PASS_REGULAR_EXPRESSION "Base at DNM position: G Base at phasing position: G	 INFERRED PARENT OF ORIGIN for DNM: p2 SUPPORTING READ COUNT: 1"
 )
+
+##### Issue 51 (and 52) - Test cases for various library identifiers (by LB, SM, and RG). ####
+# Only check the headers. Data will be different (and possibly meaningless) depending on how read-group libraries are grouped together 
+
+ADD_TEST(CALL_Sample5.3_BAM_LB_TAG ${DNG_CALL_EXE} -f ${TEST_DATA_DIR}/sample_5_3/sample-5.3_ref.fasta.gz -p ${TEST_DATA_DIR}/sample_5_3/ceu.ped -m 0.001 --lbtag "LB" ${TEST_DATA_DIR}/sample_5_3/test1.bam)
+SET_TESTS_PROPERTIES(CALL_Sample5.3_BAM_LB_TAG PROPERTIES 
+	PASS_REGULAR_EXPRESSION "FORMAT\tGL-1\tGL-2\tLB-NA12878-Solexa-135852\tLB-NA12891-Solexa-135851\tLB-NA12892-Solexa-135853"
+)
+ADD_TEST(CALL_Sample5.3_BAM_SM_TAG ${DNG_CALL_EXE} -f ${TEST_DATA_DIR}/sample_5_3/sample-5.3_ref.fasta.gz -p ${TEST_DATA_DIR}/sample_5_3/ceu.ped -m 0.001 --lbtag "SM" ${TEST_DATA_DIR}/sample_5_3/test1.bam)
+SET_TESTS_PROPERTIES(CALL_Sample5.3_BAM_SM_TAG PROPERTIES 
+	PASS_REGULAR_EXPRESSION "FORMAT\tGL-1\tGL-2\tLB-NA12878\tLB-NA12891\tLB-NA12892"
+)
+ADD_TEST(CALL_Sample5.3_BAM_ID_TAG ${DNG_CALL_EXE} -f ${TEST_DATA_DIR}/sample_5_3/sample-5.3_ref.fasta.gz -p ${TEST_DATA_DIR}/sample_5_3/ceu.ped -m 0.001 --lbtag "ID" ${TEST_DATA_DIR}/sample_5_3/test1.bam)
+SET_TESTS_PROPERTIES(CALL_Sample5.3_BAM_ID_TAG PROPERTIES 
+	PASS_REGULAR_EXPRESSION "FORMAT\tGL-1\tGL-2\tSM-NA12891\tSM-NA12892\tSM-NA12878\tLB-NA12878-H06HD.1\tLB-NA12878-H06HD.2\tLB-NA12878-H06JU.1\tLB-NA12891-H03N7.1\tLB-NA12891-H03N7.2\tLB-NA12891-H05F1.2\tLB-NA12892-H06JH.1\tLB-NA12892-H06JH.2\tLB-NA12892-H06JU.2"
+)
+


### PR DESCRIPTION
Fix for issue #51 (and possibly #52). User can now specify which SAM @RG tag to use in order to group different libraries together with the option "--lbtag".  
