### PR TITLE
AppleClang does not support thread_local

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,7 +49,6 @@ TARGET_COMPILE_FEATURES(dng-dnm PRIVATE
   cxx_attributes
   cxx_reference_qualified_functions
   cxx_decltype_incomplete_return_types
-  cxx_thread_local
 )
 
 ADD_EXECUTABLE(dng-phaser


### PR DESCRIPTION
Disable cxx_thread_local check because we can compile with out it and it creates a false positive for incompatible compiler on Apple
