### PR TITLE
Simplify Genotype Likelihood Calculations

### DIFF
--- a/src/lib/likelihood.cc
+++ b/src/lib/likelihood.cc
@@ -21,15 +21,24 @@
 #include <dng/matrix.h>
 #include <dng/likelihood.h>
 
+//  The smallest positive value such that (1-phi)/phi + 1 != (1-phi)/phi
 #ifndef DNG_LIKLIHOOD_PHI_MIN
-#   define DNG_LIKLIHOOD_PHI_MIN 1e-6
+#   define DNG_LIKLIHOOD_PHI_MIN (DBL_EPSILON/2.0)
 #endif
 
 dng::genotype::DirichletMultinomialMixture
 ::DirichletMultinomialMixture(params_t model_a, params_t model_b) :
-    cache_(5), alphas_(5) {
+    cache_(5) {
     double a, u, e, m, h;
 
+    assert(0.0 < model_a.pi && 0.0 < model_b.pi);
+    assert(0.0 <= model_a.phi && model_a.phi <= 1.0 );
+    assert(0.0 <= model_b.phi && model_b.phi <= 1.0 );
+    assert(0.0 <= model_a.epsilon && model_a.epsilon <= 1.0 );
+    assert(0.0 <= model_b.epsilon && model_b.epsilon <= 1.0 );
+    assert(0.0 < model_a.omega && 0.0 < model_b.omega);
+
+    // Calculate log(mixing proportions) and ensure that they are normalized
     f1_ = log(model_a.pi) - log(model_a.pi + model_b.pi);
     f2_ = log(model_b.pi) - log(model_a.pi + model_b.pi);
 
@@ -40,10 +49,10 @@ dng::genotype::DirichletMultinomialMixture
     }
     a = (1.0 - model_a.phi) / model_a.phi;
     u = model_a.omega;
-    e = (model_a.epsilon * u) / 3.0 / (1.0 - model_a.epsilon * (1.0 - u));
+    e = model_a.epsilon/3.0;
 
     m = 1.0 - 3.0 * e; // prob of a read that matches a homozygote
-    h = (1.0 - 2.0 * e) / 2.0; // prob of a read that matches a heterozygote
+    h = 1.0 - 2.0 * e; // prob of a read that matches a heterozygote
     for(int r = 0; r < 5; ++r) {
         for(int g = 0; g < 10; ++g) {
             double tmp[5] = {e, e, e, e, e};
@@ -51,16 +60,21 @@ dng::genotype::DirichletMultinomialMixture
             int g2 = folded_diploid_nucleotides[g][1];
             if(g1 == g2) {
                 tmp[g1] = m;
+            } else if(g1 == r) {
+                tmp[g1] = h*u/(1.0+u);
+                tmp[g2] = h*1.0/(1.0+u);
+            } else if(g2 == r) {
+                tmp[g1] = h*1.0/(1.0+u);
+                tmp[g2] = h*u/(1.0+u);
             } else {
-                tmp[g1] = h;
-                tmp[g2] = h;
+                tmp[g1] = h/2.0;
+                tmp[g2] = h/2.0;
             }
-            tmp[r] *= u;
             tmp[4] = tmp[0] + tmp[1] + tmp[2] + tmp[3];
             double aa = a / tmp[4];
             for(int x = 0; x < 5; ++x) {
-                alphas_[r][g][x][0] = aa * tmp[x];
-                alphas_[r][g][x][1] = lgamma(aa * tmp[x]);
+                // TODO: Is it worth eliminating redundant calculations?
+                cache_[r][g][x].first = cache_type{aa*tmp[x]};
             }
         }
     }
@@ -71,10 +85,10 @@ dng::genotype::DirichletMultinomialMixture
     }
     a = (1.0 - model_b.phi) / model_b.phi;
     u = model_b.omega;
-    e = (model_b.epsilon * u) / 3.0 / (1.0 - model_b.epsilon * (1.0 - u));
+    e = model_b.epsilon/3.0;
 
     m = 1.0 - 3.0 * e; // prob of a read that matches a homozygote
-    h = (1.0 - 2.0 * e) / 2.0; // prob of a read that matches a heterozygote
+    h = 1.0 - 2.0 * e; // prob of a read that matches a heterozygote
     for(int r = 0; r < 5; ++r) {
         for(int g = 0; g < 10; ++g) {
             double tmp[5] = {e, e, e, e, e};
@@ -82,31 +96,21 @@ dng::genotype::DirichletMultinomialMixture
             int g2 = folded_diploid_nucleotides[g][1];
             if(g1 == g2) {
                 tmp[g1] = m;
+            } else if(g1 == r) {
+                tmp[g1] = h*u/(1.0+u);
+                tmp[g2] = h*1.0/(1.0+u);
+            } else if(g2 == r) {
+                tmp[g1] = h*1.0/(1.0+u);
+                tmp[g2] = h*u/(1.0+u);
             } else {
-                tmp[g1] = h;
-                tmp[g2] = h;
+                tmp[g1] = h/2.0;
+                tmp[g2] = h/2.0;
             }
-            tmp[r] *= u;
             tmp[4] = tmp[0] + tmp[1] + tmp[2] + tmp[3];
             double aa = a / tmp[4];
             for(int x = 0; x < 5; ++x) {
-                alphas_[r][g][x][2] = aa * tmp[x];
-                alphas_[r][g][x][3] = lgamma(aa * tmp[x]);
-            }
-        }
-    }
-
-    // construct cache
-    for(int r = 0; r < 5; ++r) { // reference
-        for(int g = 0; g < 10; ++g) { // genotype
-            for(int x = 0; x < 5; ++x) { // nucleotide
-                double t1 = 0.0, t2 = 0.0;
-                for(int k = 0; k < kCacheSize; ++k) {
-                    cache_[r][g][x][2 * k] = t1;
-                    cache_[r][g][x][2 * k + 1] = t2;
-                    t1 += log(alphas_[r][g][x][0] + k);
-                    t2 += log(alphas_[r][g][x][2] + k);
-                }
+                // TODO: Is it worth eliminating redundant calculations?
+                cache_[r][g][x].second = cache_type{aa*tmp[x]};
             }
         }
     }


### PR DESCRIPTION
Note: This commit changes the model, and thus output. Some tests will fail until updated.

Changes:
- Genotype likelihood model has been simplied to make it easier to estimate
- a log_pochhammer functor has been designed and is more accurate than what we did before
- cache usage has been simplified based on log_pochhammer
- PHI_MIN has been descreased

Issues:
- phi = 0 is still not directly handled, i.e. we still have PHI_MIN
