### PR TITLE
Refactor peeling.cc and add tests associate with it

### DIFF
--- a/src/include/dng/peeling.h
+++ b/src/include/dng/peeling.h
@@ -109,6 +109,12 @@ struct workspace_t {
         assert(boost::size(range) == library_nodes.second - library_nodes.first);
         boost::copy(range, lower.begin() + library_nodes.first);
     }
+
+    inline dng::GenotypeArray multiply_upper_lower(std::size_t index){
+
+        return (upper[index] * lower[index]);
+    }
+
 };
 
 typedef std::vector<std::size_t> family_members_t;
@@ -124,7 +130,7 @@ dng::PairedGenotypeArray sum_over_children(workspace_t &work, const family_membe
 dng::PairedGenotypeArray sum_over_children(workspace_t &work, const family_members_t &family,
                                            const TransitionVector &mat, int first_child_index);
 
-dng::GenotypeArray multiply_upper_lower(workspace_t &work, size_t index);
+[[deprecated]] dng::GenotypeArray multiply_upper_lower(workspace_t &work, size_t index);
 
 
 [[deprecated]] dng::GenotypeArray multiply_lower_upper(workspace_t &work, size_t index);
@@ -185,6 +191,9 @@ void to_mother_reverse(workspace_t &work, const family_members_t &family,
                        const TransitionVector &mat);
 void to_child_reverse(workspace_t &work, const family_members_t &family,
                       const TransitionVector &mat);
+
+
+
 
 typedef decltype(&down) function_t;
 

--- a/src/include/dng/peeling.h
+++ b/src/include/dng/peeling.h
@@ -30,6 +30,9 @@
 
 #include <dng/matrix.h>
 #include <map>
+
+
+
 namespace dng {
 namespace peel {
 
@@ -40,6 +43,8 @@ enum {
     TOCHILDFAST,
     NUM // Total number of possible forward operations
 };
+
+
 
 std::map<decltype(peel::op::NUM), std::string> map_enum_string {
         {peel::op::UP, "UP"},
@@ -54,6 +59,9 @@ std::map<decltype(peel::op::NUM), std::string> map_enum_string {
         {peel::op::TOCHILDFAST, "TOCHILDFAST"}
 };
 } // namespace dng::peel::op
+
+#define WORKSPACE_T_MULTIPLE_UPPER_LOWER(workspace, index) \
+    (workspace.upper[index] * workspace.lower[index])
 
 struct workspace_t {
     IndividualVector upper; // Holds P(~Descendent_Data & G=g)
@@ -110,12 +118,20 @@ struct workspace_t {
         boost::copy(range, lower.begin() + library_nodes.first);
     }
 
+
     inline dng::GenotypeArray multiply_upper_lower(std::size_t index){
 
         return (upper[index] * lower[index]);
     }
+#define WORKSPACE_T_MULTIPLE_UPPER_LOWER(workspace, index) \
+    (workspace.upper[index] * workspace.lower[index])
+
+#define WORKSPACE_T_KRONECKER_PRODUCT_PARENTS(workspace, dad, mom) \
+    kroneckerProduct(WORKSPACE_T_MULTIPLE_UPPER_LOWER(work, dad).matrix(),  \
+                     WORKSPACE_T_MULTIPLE_UPPER_LOWER(work, mom).matrix() )
 
 };
+
 
 typedef std::vector<std::size_t> family_members_t;
 
@@ -135,6 +151,7 @@ dng::PairedGenotypeArray sum_over_children(workspace_t &work, const family_membe
 
 [[deprecated]] dng::GenotypeArray multiply_lower_upper(workspace_t &work, size_t index);
 
+[[deprecated]]
 dng::PairedGenotypeArray kroneckerProductDadMom(workspace_t &work,
                                                 std::size_t dad, std::size_t mom);
 

--- a/src/include/dng/peeling.h
+++ b/src/include/dng/peeling.h
@@ -29,7 +29,7 @@
 #include <boost/range/algorithm/fill_n.hpp>
 
 #include <dng/matrix.h>
-
+#include <map>
 namespace dng {
 namespace peel {
 
@@ -39,6 +39,19 @@ enum {
     UPFAST, DOWNFAST, TOFATHERFAST, TOMOTHERFAST,
     TOCHILDFAST,
     NUM // Total number of possible forward operations
+};
+
+std::map<decltype(peel::op::NUM), std::string> map_enum_string {
+        {peel::op::UP, "UP"},
+        {peel::op::DOWN, "DOWN"},
+        {peel::op::TOFATHER, "TOFATHER"},
+        {peel::op::TOMOTHER, "TOMOTHER"},
+        {peel::op::TOCHILD, "TOCHILD"},
+        {peel::op::UPFAST, "UPFAST"},
+        {peel::op::DOWNFAST, "DOWNFAST"},
+        {peel::op::TOFATHERFAST, "TOFATHERFAST"},
+        {peel::op::TOMOTHERFAST, "TOMOTHERFAST"},
+        {peel::op::TOCHILDFAST, "TOCHILDFAST"}
 };
 } // namespace dng::peel::op
 
@@ -80,6 +93,7 @@ struct workspace_t {
     void CleanupFast() {
         // TODO: create a check that sees if this has been done before the
         // forward algorithm.
+
         boost::fill_n(lower, somatic_nodes.second, DNG_INDIVIDUAL_BUFFER_ONES);
         dirty_lower = false;
     }
@@ -99,7 +113,44 @@ struct workspace_t {
 
 typedef std::vector<std::size_t> family_members_t;
 
-// Basic peeling operations
+enum class Parents : bool {Father=false, Mother=true};
+//enum class Parents : std::size_t {Father=0, Mother=1};
+//TODO: HOW TO?? auto dad = family[Parents::Father]; Dad always 0, Mom always 1
+
+// utility
+dng::PairedGenotypeArray sum_over_children(workspace_t &work, const family_members_t &family,
+                                           const TransitionVector &mat);
+
+dng::PairedGenotypeArray sum_over_children(workspace_t &work, const family_members_t &family,
+                                           const TransitionVector &mat, int first_child_index);
+
+dng::GenotypeArray multiply_upper_lower(workspace_t &work, size_t index);
+
+
+[[deprecated]] dng::GenotypeArray multiply_lower_upper(workspace_t &work, size_t index);
+
+dng::PairedGenotypeArray kroneckerProductDadMom(workspace_t &work,
+                                                std::size_t dad, std::size_t mom);
+
+
+// Core operations
+dng::GenotypeArray up_core(workspace_t &work, const family_members_t &family,
+                           const TransitionVector &mat);
+
+
+dng::GenotypeArray to_parent_core(workspace_t &work, const family_members_t &family,
+                                  const TransitionVector &mat, const Parents to_parent);
+
+[[deprecated]]
+dng::GenotypeArray to_father_core(workspace_t &work, const family_members_t &family,
+                                  const TransitionVector &mat);
+
+[[deprecated]]
+dng::GenotypeArray to_mother_core(workspace_t &work, const family_members_t &family,
+                                  const TransitionVector &mat);
+
+
+        // Basic peeling operations
 void up(workspace_t &work, const family_members_t &family,
         const TransitionVector &mat);
 void down(workspace_t &work, const family_members_t &family,

--- a/src/lib/peeling.cc
+++ b/src/lib/peeling.cc
@@ -18,152 +18,207 @@
  */
 
 #include <dng/peeling.h>
+#include <iostream>
+
+bool DEBUG = false;
+#define DEBUG_PEELING true;
+//#ifdef DEBUG_PEELING
+//    std::cout << "==" << __FUNCTION__ << "==" << std::endl;
+//#endif
+
+dng::GenotypeArray dng::peel::multiply_upper_lower(workspace_t &work, std::size_t index){
+
+    return (work.upper[index] * work.lower[index]);
+}
+
+[[deprecated]]
+dng::GenotypeArray dng::peel::multiply_lower_upper(workspace_t &work, std::size_t index){
+    return multiply_upper_lower(work, index);
+}
+
+
+dng::PairedGenotypeArray dng::peel::kroneckerProductDadMom(workspace_t &work, std::size_t dad, std::size_t mom){
+
+    dng::PairedGenotypeArray result = kroneckerProduct(
+            multiply_upper_lower(work, dad).matrix(),
+            multiply_upper_lower(work, mom).matrix());
+    return result;
+
+}
+
+
+// Family Order: Father, Mother, Child1, Child2, ...
+dng::PairedGenotypeArray dng::peel::sum_over_children(workspace_t &work, const family_members_t &family,
+                                                      const TransitionVector &mat) {
+    PairedGenotypeArray buffer = sum_over_children(work, family, mat, 2);
+    return buffer;
+}
+
+// Family Order: Father, Mother, Child1, Child2, ...
+dng::PairedGenotypeArray dng::peel::sum_over_children(workspace_t &work, const family_members_t &family,
+                                                      const TransitionVector &mat, int first_child_index) {
+    assert(family.size() >= 3);
+    assert(family.size() >= first_child_index);
+    PairedGenotypeArray buffer = PairedGenotypeArray::Ones(100,1);
+    for(std::size_t i = first_child_index; i < family.size(); ++i) {
+        buffer *= (mat[family[i]] * work.lower[family[i]].matrix()).array();
+    }
+    return buffer;
+}
+
+
+// Family Order: Parent, Child
+dng::GenotypeArray dng::peel::up_core(workspace_t &work, const family_members_t &family,
+                                      const TransitionVector &mat) {
+
+    assert(family.size() == 2);
+    auto child = family[1];
+    dng::GenotypeArray geno_array = (mat[child] * work.lower[child].matrix()).array();
+    return geno_array;
+}
+
+
+// Family Order: Father, Mother, Child1, Child2, ...
+dng::GenotypeArray dng::peel::to_parent_core(workspace_t &work, const family_members_t &family,
+                                             const TransitionVector &mat, const Parents to_parent) {
+
+    assert(family.size() >= 3);
+    auto dad = family[0];
+    auto mom = family[1];
+
+    work.paired_buffer = sum_over_children(work, family, mat);
+    work.paired_buffer.resize(10, 10);
+
+    GenotypeArray parent_array;
+    if(to_parent == Parents::Father) {
+        PairedGenotypeArray other_parent = multiply_upper_lower(work, mom);
+        parent_array = (work.paired_buffer.matrix() * other_parent.matrix() ).array();
+    }
+    else if (to_parent == Parents::Mother){
+        PairedGenotypeArray other_parent = multiply_upper_lower(work, dad);
+        parent_array = (work.paired_buffer.matrix().transpose() * other_parent.matrix() ).array();
+    }
+    else{
+        //ERROR: Not possible until we add more enum!!
+    }
+
+
+    return parent_array;
+}
+
 
 // Family Order: Parent, Child
 void dng::peel::down(workspace_t &work, const family_members_t &family,
                      const TransitionVector &mat) {
+    if(DEBUG){ std::cout << "==" << __FUNCTION__ << "==" << std::endl; }
+
     assert(family.size() == 2);
     auto parent = family[0];
     auto child = family[1];
-    work.upper[child] = (mat[child].transpose() * (work.upper[parent] *
-                         work.lower[parent]).matrix()).array();
+    auto parent_upper_lower = multiply_upper_lower(work, parent);
+    work.upper[child] = (mat[child].transpose() * parent_upper_lower.matrix()).array();
 }
 
 // Family Order: Parent, Child
 void dng::peel::down_fast(workspace_t &work, const family_members_t &family,
                           const TransitionVector &mat) {
+    if(DEBUG){ std::cout << "==" << __FUNCTION__ << "==" << std::endl; }
+
     assert(family.size() == 2);
     auto parent = family[0];
     auto child = family[1];
-    work.upper[child] = (mat[child].transpose() *
-                         work.upper[parent].matrix()).array();
+    work.upper[child] = (mat[child].transpose() * work.upper[parent].matrix()).array();
+
 }
 
 // Family Order: Parent, Child
 void dng::peel::up(workspace_t &work, const family_members_t &family,
                    const TransitionVector &mat) {
-    assert(family.size() == 2);
+    if(DEBUG){ std::cout << "==" << __FUNCTION__ << "==" << std::endl; }
+
     auto parent = family[0];
-    auto child = family[1];
-    work.lower[parent] *= (mat[child] * work.lower[child].matrix()).array();
+    work.lower[parent] *= up_core(work, family, mat);
 }
 
 // Family Order: Parent, Child
 void dng::peel::up_fast(workspace_t &work, const family_members_t &family,
                         const TransitionVector &mat) {
-    assert(family.size() == 2);
+    if(DEBUG){ std::cout << "==" << __FUNCTION__ << "==" << std::endl; }
     auto parent = family[0];
-    auto child = family[1];
-    work.lower[parent] = (mat[child] * work.lower[child].matrix()).array();
+    work.lower[parent] = up_core(work, family, mat);
 }
+
+
 
 // Family Order: Father, Mother, Child1, Child2, ...
 void dng::peel::to_father(workspace_t &work, const family_members_t &family,
                           const TransitionVector &mat) {
-    assert(family.size() >= 3);
+    if(DEBUG){ std::cout << "==" << __FUNCTION__ << "==" << std::endl; }
     auto dad = family[0];
-    auto mom = family[1];
-    // Sum over children
-    work.paired_buffer = (mat[family[2]] * work.lower[family[2]].matrix()).array();
-    for(std::size_t i = 3; i < family.size(); ++i) {
-        work.paired_buffer *= (mat[family[i]] * work.lower[family[i]].matrix()).array();
-    }
-    // Include Mom
-    work.paired_buffer.resize(10, 10);
-    work.lower[dad] *= (work.paired_buffer.matrix() * (work.upper[mom] *
-                        work.lower[mom]).matrix()).array();
-    work.paired_buffer.resize(100, 1);
+    work.lower[dad] *= to_parent_core(work, family, mat, Parents::Father);
 }
 
 // Family Order: Father, Mother, Child1, Child2, ...
-void dng::peel::to_father_fast(workspace_t &work,
-                               const family_members_t &family, const TransitionVector &mat) {
-    assert(family.size() >= 3);
+void dng::peel::to_father_fast(workspace_t &work, const family_members_t &family,
+                               const TransitionVector &mat) {
+    if(DEBUG){ std::cout << "==" << __FUNCTION__ << "==" << std::endl; }
     auto dad = family[0];
-    auto mom = family[1];
-    // Sum over children
-    work.paired_buffer = (mat[family[2]] * work.lower[family[2]].matrix()).array();
-    for(std::size_t i = 3; i < family.size(); ++i) {
-        work.paired_buffer *= (mat[family[i]] * work.lower[family[i]].matrix()).array();
-    }
-    // Include Mom
-    work.paired_buffer.resize(10, 10);
-    work.lower[dad] = (work.paired_buffer.matrix() * (work.upper[mom] *
-                       work.lower[mom]).matrix()).array();
-    work.paired_buffer.resize(100, 1);
+    work.lower[dad] =  to_parent_core(work, family, mat, Parents::Father);
+
 }
 
 // Family Order: Father, Mother, Child1, Child2, ...
 void dng::peel::to_mother(workspace_t &work, const family_members_t &family,
                           const TransitionVector &mat) {
-    assert(family.size() >= 3);
-    auto dad = family[0];
+    if(DEBUG){ std::cout << "==" << __FUNCTION__ << "==" << std::endl; }
     auto mom = family[1];
-    // Sum over children
-    work.paired_buffer = (mat[family[2]] * work.lower[family[2]].matrix()).array();
-    for(size_t i = 3; i < family.size(); ++i) {
-        work.paired_buffer *= (mat[family[i]] * work.lower[family[i]].matrix()).array();
-    }
-    // Include Dad
-    work.paired_buffer.resize(10, 10);
-    work.lower[mom] *= (work.paired_buffer.matrix().transpose() * (work.upper[dad] *
-                        work.lower[dad]).matrix()).array();
-    work.paired_buffer.resize(100, 1);
+    work.lower[mom] *= to_parent_core(work, family, mat, Parents::Mother);
 }
 
 // Family Order: Father, Mother, Child1, Child2, ...
 void dng::peel::to_mother_fast(workspace_t &work,
                                const family_members_t &family, const TransitionVector &mat) {
-    assert(family.size() >= 3);
-    auto dad = family[0];
+    if(DEBUG){ std::cout << "==" << __FUNCTION__ << "==" << std::endl; }
     auto mom = family[1];
-    // Sum over children
-    work.paired_buffer = (mat[family[2]] * work.lower[family[2]].matrix()).array();
-    for(std::size_t i = 3; i < family.size(); ++i) {
-        work.paired_buffer *= (mat[family[i]] * work.lower[family[i]].matrix()).array();
-    }
-    // Include Dad
-    work.paired_buffer.resize(10, 10);
-    work.lower[mom] = (work.paired_buffer.matrix().transpose() * (work.upper[dad] *
-                       work.lower[dad]).matrix()).array();
-    work.paired_buffer.resize(100, 1);
+    work.lower[mom] = to_parent_core(work, family, mat, Parents::Mother);
 }
+
+
+
 
 // Family Order: Father, Mother, Child, Child2, ....
 void dng::peel::to_child(workspace_t &work, const family_members_t &family,
                          const TransitionVector &mat) {
+    if(DEBUG){ std::cout << "==" << __FUNCTION__ << "==" << std::endl; }
     assert(family.size() >= 4);
     auto dad = family[0];
     auto mom = family[1];
     auto child = family[2];
     // Parents
-    work.paired_buffer = kroneckerProduct((work.lower[dad] *
-                                           work.upper[dad]).matrix(),
-                                          (work.lower[mom] * work.upper[mom]).matrix()).array();
-    // Sum over fullsibs
-    for(std::size_t i = 3; i < family.size(); ++i) {
-        work.paired_buffer *= (mat[family[i]] * work.lower[family[i]].matrix()).array();
-    }
+    work.paired_buffer = kroneckerProductDadMom(work, dad, mom).array();
+    work.paired_buffer *= sum_over_children(work, family, mat, 3);
+    work.upper[child] = (mat[child].transpose() * work.paired_buffer.matrix()).array();
 
-    work.upper[child] = (mat[child].transpose() *
-                         work.paired_buffer.matrix()).array();
 }
 
 // Family Order: Father, Mother, CHild
 void dng::peel::to_child_fast(workspace_t &work, const family_members_t &family,
                               const TransitionVector &mat) {
+    if(DEBUG){ std::cout << "==" << __FUNCTION__ << "==" << std::endl; }
     assert(family.size() == 3);
     auto dad = family[0];
     auto mom = family[1];
     auto child = family[2];
-    work.upper[child] = (mat[child].transpose() * kroneckerProduct(
-                             (work.lower[dad] * work.upper[dad]).matrix(),
-                             (work.lower[mom] * work.upper[mom]).matrix())).array();
+    // Parents
+    work.paired_buffer = kroneckerProductDadMom(work, dad, mom).array();
+
+    work.upper[child] = (mat[child].transpose() * work.paired_buffer.matrix()).array();
 }
 
 // Family Order: Parent, Child
 void dng::peel::down_reverse(workspace_t &work, const family_members_t &family,
                              const TransitionVector &mat) {
+    if(DEBUG){ std::cout << "==" << __FUNCTION__ << "==" << std::endl; }
     assert(family.size() == 2);
     auto parent = family[0];
     auto child = family[1];
@@ -176,6 +231,7 @@ void dng::peel::down_reverse(workspace_t &work, const family_members_t &family,
 // prevent divide by zero errors by adding a minor offset to one of the calculations
 void dng::peel::up_reverse(workspace_t &work, const family_members_t &family,
                            const TransitionVector &mat) {
+    if(DEBUG){ std::cout << "==" << __FUNCTION__ << "==" << std::endl; }
     assert(family.size() == 2);
     auto parent = family[0];
     auto child = family[1];
@@ -190,6 +246,7 @@ void dng::peel::up_reverse(workspace_t &work, const family_members_t &family,
 // Family Order: Father, Mother, Child1, Child2, ...
 void dng::peel::to_father_reverse(workspace_t &work,
                                   const family_members_t &family, const TransitionVector &mat) {
+    if(DEBUG){ std::cout << "==" << __FUNCTION__ << "==" << std::endl; }
     assert(family.size() >= 3);
     auto dad = family[0];
     auto mom = family[1];
@@ -228,6 +285,7 @@ void dng::peel::to_father_reverse(workspace_t &work,
 // Family Order: Father, Mother, Child1, Child2, ...
 void dng::peel::to_mother_reverse(workspace_t &work,
                                   const family_members_t &family, const TransitionVector &mat) {
+    if(DEBUG){ std::cout << "==" << __FUNCTION__ << "==" << std::endl; }
     assert(family.size() >= 3);
     auto dad = family[0];
     auto mom = family[1];
@@ -258,6 +316,7 @@ void dng::peel::to_mother_reverse(workspace_t &work,
 // Family Order: Father, Mother, Child1, Child2, ...
 void dng::peel::to_child_reverse(workspace_t &work,
                                  const family_members_t &family, const TransitionVector &mat) {
+    if(DEBUG){ std::cout << "==" << __FUNCTION__ << "==" << std::endl; }
     assert(family.size() >= 3);
     auto dad = family[0];
     auto mom = family[1];
@@ -287,3 +346,45 @@ void dng::peel::to_child_reverse(workspace_t &work,
         work.upper[child] = mat[child].transpose() * work.super[child].matrix();
     }
 }
+
+
+
+
+
+// Family Order: Father, Mother, Child1, Child2, ...
+//[[deprecated]]
+dng::GenotypeArray dng::peel::to_father_core(workspace_t &work, const family_members_t &family,
+                                             const TransitionVector &mat) {
+
+    assert(family.size() >= 3);
+    auto dad = family[0];
+    auto mom = family[1];
+
+//    work.paired_buffer = sum_over_children(work, family, mat);
+//    // Include Mom
+//    work.paired_buffer.resize(10, 10);
+//    PairedGenotypeArray other_parent = multiply_upper_lower(work, mom);
+//    GenotypeArray dad_array = (work.paired_buffer.matrix() * other_parent.matrix() ).array();
+    GenotypeArray dad_array = to_parent_core(work, family, mat, Parents::Father);
+
+    return dad_array;
+}
+// Family Order: Father, Mother, Child1, Child2, ...
+[[deprecated]]
+dng::GenotypeArray dng::peel::to_mother_core(workspace_t &work, const family_members_t &family,
+                                             const TransitionVector &mat) {
+
+    assert(family.size() >= 3);
+    auto dad = family[0];
+    auto mom = family[1];
+
+//    work.paired_buffer = sum_over_children(work, family, mat);
+//    // Include Mom
+//    work.paired_buffer.resize(10, 10);
+//    PairedGenotypeArray other_parent = multiply_upper_lower(work, dad);
+//    GenotypeArray mom_array = (work.paired_buffer.matrix().transpose() * other_parent.matrix() ).array();
+    GenotypeArray  mom_array = to_parent_core(work, family, mat, Parents::Mother);
+    return mom_array;
+}
+
+

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -57,8 +57,9 @@ endforeach(test)
 
 ################################################################################
 ## TODO: How to build something like "make timetrail" and compile all time measuring files
-
-
+IF(DEVEL_MODE)
+  ADD_DEFINITIONS(-DDNG_DEVEL)
+ENDIF()
 file(GLOB_RECURSE TESTS2 "testt_time*[cc|cpp]")
 foreach(test ${TESTS2})
   get_filename_component(testName ${test} NAME_WE)
@@ -75,6 +76,7 @@ foreach(test ${TESTS2})
           Boost::UNIT_TEST_FRAMEWORK
           EIGEN3::EIGEN3
           HTSLIB::HTSLIB
+#          Boost::TIMER
           )
 #  add_test(${testName}_build "${CMAKE_COMMAND}" --build ${CMAKE_BINARY_DIR} --target ${testName})
 #  add_test(${testName}_run ${testName})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -56,10 +56,40 @@ endforeach(test)
 
 
 ################################################################################
-# temp Compile unit tests with *.cc
+## TODO: How to build something like "make timetrail" and compile all time measuring files
+
+
+file(GLOB_RECURSE TESTS2 "testt_time*[cc|cpp]")
+foreach(test ${TESTS2})
+  get_filename_component(testName ${test} NAME_WE)
+  add_executable(${testName} EXCLUDE_FROM_ALL ${test}
+          ${CMAKE_SOURCE_DIR}/src/lib/peeling.cc
+          ##            ../src/lib/likelihood.cc ../src/lib/newick.cc ../src/lib/pedigree.cc
+          ##            ../src/lib/mutation.cc ../src/lib/stats.cc
+          )
+  target_link_libraries(${testName}
+          Threads::Threads
+          Boost::PROGRAM_OPTIONS
+          Boost::FILESYSTEM
+          Boost::SYSTEM
+          Boost::UNIT_TEST_FRAMEWORK
+          EIGEN3::EIGEN3
+          HTSLIB::HTSLIB
+          )
+#  add_test(${testName}_build "${CMAKE_COMMAND}" --build ${CMAKE_BINARY_DIR} --target ${testName})
+#  add_test(${testName}_run ${testName})
+#  set_tests_properties(${testName}_run PROPERTIES DEPENDS ${testName}_build)
+endforeach(test)
+
+
+
+
+
+## temp Compile unit tests with *.cc
 # TODO: Use a different filename pattern for now (test2_* instead of test_*).
 # TODO: How to add min *.cc files instead of all *.cc later?
 include_directories(./)
+include_directories(./lib/)
 
 file(GLOB_RECURSE TESTS2 "test2_*[cc|cpp]")
 foreach(test ${TESTS2})

--- a/test/src/lib/test2_peeling.cpp
+++ b/test/src/lib/test2_peeling.cpp
@@ -13,9 +13,10 @@
 #include <iostream>
 
 #include <dng/peeling.h>
+#include <chrono>
 
 #include "boost_test_helper.h"
-
+#include "testh_helper_peeling.h"
 //#include <boost/test/data/test_case.hpp>
 ////#include <boost/test/data/monomorphic.hpp>
 //namespace data = boost::unit_test::data;
@@ -24,80 +25,6 @@ using namespace dng;
 namespace utf = boost::unit_test;
 
 const int NUM_TEST = 100;
-
-std::random_device rd;
-std::mt19937 random_gen_mt(rd());
-
-struct Fx {
-
-    const int CHILD_OFFSET = 2;
-    std::string fixture;
-
-    dng::peel::family_members_t family;
-    std::vector<TransitionMatrix> trans_matrix;
-    std::vector<GenotypeArray> upper_array;
-    std::vector<GenotypeArray> lower_array;
-
-    int num_child;
-    int total_family_size;
-    std::uniform_int_distribution<> rand_unif;
-
-    Fx(std::string s = "") : fixture(s) {
-        BOOST_TEST_MESSAGE("set up fixture " << s);
-        rand_unif = std::uniform_int_distribution<>(1,10);
-        init_family();
-    }
-
-    void init_family(){
-
-        int num_child = rand_unif(random_gen_mt);
-        total_family_size = num_child + CHILD_OFFSET;
-
-        family.clear();
-        trans_matrix.resize(total_family_size);
-        upper_array.resize(total_family_size);
-        lower_array.resize(total_family_size);
-
-        for (int k = 0; k < total_family_size; ++k) {
-            family.push_back(k);
-            lower_array[k] = GenotypeArray::Random();
-            if (k < CHILD_OFFSET) {
-                trans_matrix[k] = TransitionMatrix::Random(10, 10);
-                upper_array[k] = GenotypeArray::Random();
-            }
-            else {
-                trans_matrix[k] = TransitionMatrix::Random(100, 10);
-            }
-
-        }
-    }
-
-    void init_family_parent_child_only(){
-
-        total_family_size = 2;
-
-        family.clear();
-        trans_matrix.resize(total_family_size);
-        upper_array.resize(total_family_size);
-        lower_array.resize(total_family_size);
-
-        for (int k = 0; k < total_family_size; ++k) {
-            family.push_back(k);
-            trans_matrix[k] = TransitionMatrix::Random(10, 10);
-            lower_array[k] = GenotypeArray::Random();
-//            upper_array[k] = GenotypeArray::Random();
-
-        }
-    }
-
-    ~Fx() {
-        BOOST_TEST_MESSAGE("tear down fixture " << fixture);
-    }
-};
-
-void setup() { BOOST_TEST_MESSAGE("set up fun"); }
-
-void teardown() { BOOST_TEST_MESSAGE("tear down fun"); }
 
 
 // TODO: Example of BOOST_DATA_TEST_CASE and BOOST_PARAM_TEST_CASE.
@@ -131,19 +58,6 @@ void teardown() { BOOST_TEST_MESSAGE("tear down fun"); }
 //BOOST_PARAM_TEST_CASE(test_function, params_begin, params_end);
 //BOOST_AUTO_TEST_SUITE_END()
 
-
-void copy_family_to_workspace(peel::workspace_t &workspace, dng::TransitionVector &full_matrix,
-                              int total_family_size, const std::vector<GenotypeArray> &lower,
-                              const std::vector<GenotypeArray> &upper,
-                              const std::vector<TransitionMatrix> &trans_mat) {
-    workspace.Resize(total_family_size);
-    full_matrix.resize(total_family_size);
-    for (int l = 0; l < total_family_size; ++l) {
-        workspace.lower[l] = lower[l];
-        workspace.upper[l] = upper[l];
-        full_matrix[l] = trans_mat[l];
-    }
-}
 
 //BOOST_AUTO_TEST_SUITE(test_peeling_suite,  * utf::fixture<Fx>(std::string("FX")) )
 BOOST_FIXTURE_TEST_SUITE(test_peeling_suite, Fx)
@@ -456,3 +370,4 @@ BOOST_FIXTURE_TEST_SUITE(test_peeling_suite, Fx)
     }
 
 BOOST_AUTO_TEST_SUITE_END()
+

--- a/test/src/lib/testh_helper_peeling.h
+++ b/test/src/lib/testh_helper_peeling.h
@@ -1,0 +1,101 @@
+//
+// Created by steven on 1/24/16.
+//
+
+#ifndef DENOVOGEAR_TESTH_HELPER_PEELING_H
+#define DENOVOGEAR_TESTH_HELPER_PEELING_H
+
+#include <dng/peeling.h>
+
+//TODO: Fix this files!! New filename system and mixed global and local here.
+std::random_device rd;
+std::mt19937 random_gen_mt(rd());
+
+struct Fx {
+
+    const int CHILD_OFFSET = 2;
+    std::string fixture;
+
+    dng::peel::family_members_t family;
+    std::vector<dng::TransitionMatrix> trans_matrix;
+    std::vector<dng::GenotypeArray> upper_array;
+    std::vector<dng::GenotypeArray> lower_array;
+
+    int num_child;
+    int total_family_size;
+    std::uniform_int_distribution<> rand_unif;
+
+    Fx(std::string s = "") : fixture(s) {
+        BOOST_TEST_MESSAGE("set up fixture " << s);
+        rand_unif = std::uniform_int_distribution<>(1,10);
+        init_family();
+    }
+
+    void init_family(){
+
+        int num_child = rand_unif(random_gen_mt);
+        total_family_size = num_child + CHILD_OFFSET;
+
+        family.clear();
+        trans_matrix.resize(total_family_size);
+        upper_array.resize(total_family_size);
+        lower_array.resize(total_family_size);
+
+        for (int k = 0; k < total_family_size; ++k) {
+            family.push_back(k);
+            lower_array[k] = dng::GenotypeArray::Random();
+            if (k < CHILD_OFFSET) {
+                trans_matrix[k] = dng::TransitionMatrix::Random(10, 10);
+                upper_array[k] = dng::GenotypeArray::Random();
+            }
+            else {
+                trans_matrix[k] = dng::TransitionMatrix::Random(100, 10);
+            }
+
+        }
+    }
+
+    void init_family_parent_child_only(){
+
+        total_family_size = 2;
+
+        family.clear();
+        trans_matrix.resize(total_family_size);
+        upper_array.resize(total_family_size);
+        lower_array.resize(total_family_size);
+
+        for (int k = 0; k < total_family_size; ++k) {
+            family.push_back(k);
+            trans_matrix[k] = dng::TransitionMatrix::Random(10, 10);
+            lower_array[k] = dng::GenotypeArray::Random();
+//            upper_array[k] = GenotypeArray::Random();
+
+        }
+    }
+
+    ~Fx() {
+        BOOST_TEST_MESSAGE("tear down fixture " << fixture);
+    }
+};
+
+void setup() { BOOST_TEST_MESSAGE("set up fun"); }
+
+void teardown() { BOOST_TEST_MESSAGE("tear down fun"); }
+
+
+
+
+void copy_family_to_workspace(dng::peel::workspace_t &workspace, dng::TransitionVector &full_matrix,
+                              int total_family_size, const std::vector<dng::GenotypeArray> &lower,
+                              const std::vector<dng::GenotypeArray> &upper,
+                              const std::vector<dng::TransitionMatrix> &trans_mat) {
+    workspace.Resize(total_family_size);
+    full_matrix.resize(total_family_size);
+    for (int l = 0; l < total_family_size; ++l) {
+        workspace.lower[l] = lower[l];
+        workspace.upper[l] = upper[l];
+        full_matrix[l] = trans_mat[l];
+    }
+}
+
+#endif //DENOVOGEAR_TESTH_HELPER_PEELING_H

--- a/test/src/lib/testt_time_peeling.cpp
+++ b/test/src/lib/testt_time_peeling.cpp
@@ -6,6 +6,7 @@
 
 #include <boost/test/unit_test.hpp>
 #include <boost/test/tools/floating_point_comparison.hpp>
+#include <boost/timer/timer.hpp>
 
 #include <string>
 #include <cstdlib>
@@ -89,38 +90,41 @@ BOOST_AUTO_TEST_CASE(test_speed_to_father) {
 
         GenotypeArray temp_result;
 
-
-        //Updated version
-        temp_result = GenotypeArray::Zero();
-        start = std::chrono::system_clock::now();
-        for (int t = 0; t < num_repeat; ++t) {
-            workspace.lower[0] = lower_array[0];
-//            dng::peel::to_father_fast(workspace, family, full_matrix);
-            dng::peel::to_father(workspace, family, full_matrix);
-            GenotypeArray result = workspace.lower[0];
-            temp_result += result;
+        {
+            //Updated version
+//            boost::timer::auto_cpu_timer measure_speed(std::cerr);
+            temp_result = GenotypeArray::Zero();
+            start = std::chrono::system_clock::now();
+            for (int t = 0; t < num_repeat; ++t) {
+                workspace.lower[0] = lower_array[0];
+                //            dng::peel::to_father_fast(workspace, family, full_matrix);
+                dng::peel::to_father(workspace, family, full_matrix);
+                GenotypeArray result = workspace.lower[0];
+                temp_result += result;
+            }
+            end = std::chrono::system_clock::now();
+            elapsed_seconds = end - start;
+            elapsed_update += elapsed_seconds;
+            //        std::cout << "Updated time: " << elapsed_seconds.count() << "s\t" << temp_result.sum() << std::endl;
         }
-        end = std::chrono::system_clock::now();
-        elapsed_seconds = end-start;
-        elapsed_update += elapsed_seconds;
-//        std::cout << "Updated time: " << elapsed_seconds.count() << "s\t" << temp_result.sum() << std::endl;
 
-
-        //Original version
-        temp_result = GenotypeArray::Zero();
-        start = std::chrono::system_clock::now();
-        for (int t = 0; t < num_repeat; ++t) {
-            workspace.lower[0] = lower_array[0];
+        {
+            //Original version
+//            boost::timer::auto_cpu_timer measure_speed(std::cerr);
+            temp_result = GenotypeArray::Zero();
+            start = std::chrono::system_clock::now();
+            for (int t = 0; t < num_repeat; ++t) {
+                workspace.lower[0] = lower_array[0];
 //            dng::peel::to_father_fast_original(workspace, family, full_matrix);
-            to_father_original(workspace, family, full_matrix);
-            GenotypeArray result_original = workspace.lower[0];
-            temp_result += result_original;
-        }
-        end = std::chrono::system_clock::now();
-        elapsed_seconds = end-start;
-        elapsed_original += elapsed_seconds;
+                to_father_original(workspace, family, full_matrix);
+                GenotypeArray result_original = workspace.lower[0];
+                temp_result += result_original;
+            }
+            end = std::chrono::system_clock::now();
+            elapsed_seconds = end - start;
+            elapsed_original += elapsed_seconds;
 //        std::cout << "Original time: " << elapsed_seconds.count() << "s\t" << temp_result.sum() << std::endl;
-
+        }
     }
 
     double total = num_time_trial*num_repeat;
@@ -134,3 +138,14 @@ BOOST_AUTO_TEST_CASE(test_speed_to_father) {
 
 
 BOOST_AUTO_TEST_SUITE_END()
+
+
+
+/*
+Summary: 1e+07 calls.
+*** No errors detected
+Original total: 34.8541 each: 3.48541e-06
+Update   total: 33.3654 each: 3.33654e-06
+delta/origin: -0.0427128
+
+*/

--- a/test/src/lib/testt_time_peeling.cpp
+++ b/test/src/lib/testt_time_peeling.cpp
@@ -1,0 +1,136 @@
+//
+// Created by steven on 1/15/16.
+//
+
+#define BOOST_TEST_MODULE dng::lib::peeling
+
+#include <boost/test/unit_test.hpp>
+#include <boost/test/tools/floating_point_comparison.hpp>
+
+#include <string>
+#include <cstdlib>
+#include <ctime>
+#include <iostream>
+
+#include <dng/peeling.h>
+#include <chrono>
+
+#include "boost_test_helper.h"
+#include "testh_helper_peeling.h"
+
+//Time trail/perforamnce test. Will take longer to run than normal test.
+using namespace dng;
+namespace utf = boost::unit_test;
+
+void to_father_fast_original(dng::peel::workspace_t &work, const dng::peel::family_members_t &family,
+                                        const TransitionVector &mat) {
+
+    assert(family.size() >= 3);
+    auto dad = family[0];
+    auto mom = family[1];
+    // Sum over children
+    work.paired_buffer = (mat[family[2]] * work.lower[family[2]].matrix()).array();
+    for(std::size_t i = 3; i < family.size(); ++i) {
+        work.paired_buffer *= (mat[family[i]] * work.lower[family[i]].matrix()).array();
+    }
+    // Include Mom
+    work.paired_buffer.resize(10, 10);
+    work.lower[dad] = (work.paired_buffer.matrix() * (work.upper[mom] *
+                                                      work.lower[mom]).matrix()).array();
+    work.paired_buffer.resize(100, 1);
+}
+
+
+void to_father_original(dng::peel::workspace_t &work, const dng::peel::family_members_t &family,
+                                   const TransitionVector &mat) {
+
+    assert(family.size() >= 3);
+    auto dad = family[0];
+    auto mom = family[1];
+    // Sum over children
+    work.paired_buffer = (mat[family[2]] * work.lower[family[2]].matrix()).array();
+    for(std::size_t i = 3; i < family.size(); ++i) {
+        work.paired_buffer *= (mat[family[i]] * work.lower[family[i]].matrix()).array();
+    }
+    // Include Mom
+    work.paired_buffer.resize(10, 10);
+    work.lower[dad] *= (work.paired_buffer.matrix() * (work.upper[mom] *
+                                                       work.lower[mom]).matrix()).array();
+    work.paired_buffer.resize(100, 1);
+}
+
+
+BOOST_FIXTURE_TEST_SUITE(test_peeling_speed, Fx)
+
+BOOST_AUTO_TEST_CASE(test_speed_to_father) {
+
+    const int num_time_trial = 1e3;
+    const int num_repeat = 1e4;
+
+    std::chrono::duration<double> elapsed_seconds, elapsed_update, elapsed_original;
+    std::chrono::time_point<std::chrono::system_clock> start, end;
+    std::time_t start_time, end_time;
+
+    elapsed_update = {};
+    elapsed_original = {};
+    int verbose_gap = num_time_trial/10;
+    for (int r = 0; r < num_time_trial; ++r) {
+        if( (r % verbose_gap) == 0){
+            std::cout << "At "<< (r/verbose_gap) << "0 %"<< std::endl;
+        }
+
+
+        init_family();
+
+        dng::peel::workspace_t workspace;
+        dng::TransitionVector full_matrix;
+        copy_family_to_workspace(workspace, full_matrix, total_family_size,
+                                     lower_array, upper_array, trans_matrix);
+
+        GenotypeArray temp_result;
+
+
+        //Updated version
+        temp_result = GenotypeArray::Zero();
+        start = std::chrono::system_clock::now();
+        for (int t = 0; t < num_repeat; ++t) {
+            workspace.lower[0] = lower_array[0];
+//            dng::peel::to_father_fast(workspace, family, full_matrix);
+            dng::peel::to_father(workspace, family, full_matrix);
+            GenotypeArray result = workspace.lower[0];
+            temp_result += result;
+        }
+        end = std::chrono::system_clock::now();
+        elapsed_seconds = end-start;
+        elapsed_update += elapsed_seconds;
+//        std::cout << "Updated time: " << elapsed_seconds.count() << "s\t" << temp_result.sum() << std::endl;
+
+
+        //Original version
+        temp_result = GenotypeArray::Zero();
+        start = std::chrono::system_clock::now();
+        for (int t = 0; t < num_repeat; ++t) {
+            workspace.lower[0] = lower_array[0];
+//            dng::peel::to_father_fast_original(workspace, family, full_matrix);
+            to_father_original(workspace, family, full_matrix);
+            GenotypeArray result_original = workspace.lower[0];
+            temp_result += result_original;
+        }
+        end = std::chrono::system_clock::now();
+        elapsed_seconds = end-start;
+        elapsed_original += elapsed_seconds;
+//        std::cout << "Original time: " << elapsed_seconds.count() << "s\t" << temp_result.sum() << std::endl;
+
+    }
+
+    double total = num_time_trial*num_repeat;
+    std::cout << "Summary: "<< total << " calls." << std::endl;
+    std::cout << "Original total: " << elapsed_original.count() <<
+            " each: " << elapsed_original.count()/total << std::endl;
+    std::cout << "Update   total: " << elapsed_update.count() <<
+            " each: " << elapsed_update.count()/total << std::endl;
+    std::cout << "delta/origin: "<< (elapsed_update-elapsed_original)/elapsed_original << std::endl;
+}
+
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Issue #80
Refactor peeling.cc, forward only
- add up_core() and to_parent_core() to simplify the code.
- Add a few utility functions, such as sum_over_children(), multiply_upper_lower(). Some might change after refactor reverse functions.

Add 3 boost_test
- test_sum_over_child
- test_up_core
- test_down

TODO:
- Some of these might be better in struct workspace_t
- Better check/testing for "family" can be parent-child or Dad-mom-child
- Check reverse functions
- Some debug codes might be redundant
