### PR TITLE
Fix Issues Identified using GCC 4.8

### DIFF
--- a/src/dng-dnm.cc
+++ b/src/dng-dnm.cc
@@ -45,14 +45,14 @@ int callMakeSNPLookup(lookup_table_t &tgtSNP, lookup_snp_t &lookupSNP,
     }
 
     cerr << "\nCreated SNP lookup table\n";
-    cerr << " First mrate: " << lookupSNP.mrate(1,
-            1) << " last: " << lookupSNP.mrate(100, 10) << endl;
-    cerr << " First code: " << lookupSNP.code(1,
-            1) << " last: " << lookupSNP.code(100, 10) << endl;
+    cerr << " First mrate: " << lookupSNP.mrate(0,
+            0) << " last: " << lookupSNP.mrate(99, 9) << endl;
+    cerr << " First code: " << lookupSNP.code(0,
+            0) << " last: " << lookupSNP.code(99, 9) << endl;
     cerr << " First target string: " << tgtSNP[0][0] << " last: " << tgtSNP[99][9]
          << endl;
-    cerr << " First tref: " << lookupSNP.tref(1,
-            1) << " last: " << lookupSNP.tref(100, 10) << endl;
+    cerr << " First tref: " << lookupSNP.tref(0,
+            0) << " last: " << lookupSNP.tref(99, 9) << endl;
     return 0;
 }
 
@@ -76,12 +76,12 @@ int callMakeINDELLookup(lookup_table_t &tgtIndel, lookup_indel_t &lookupIndel,
     }
 
     std::cerr << "\nCreated indel lookup table";
-    std::cerr << " First code: " << lookupIndel.code(1,
-              1) << " last: " << lookupIndel.code(9, 3) << std::endl;
+    std::cerr << " First code: " << lookupIndel.code(0,
+              0) << " last: " << lookupIndel.code(8, 2) << std::endl;
     std::cerr << " First target string: " << tgtIndel[0][0] << " last: " <<
               tgtIndel[8][2] << std::endl;
-    std::cerr << " First prior: " << lookupIndel.priors(1,
-              1) << " last: " << lookupIndel.priors(9, 3) << std::endl;
+    std::cerr << " First prior: " << lookupIndel.priors(0,
+              0) << " last: " << lookupIndel.priors(8, 2) << std::endl;
     return 0;
 }
 
@@ -97,8 +97,8 @@ int callMakePairedLookup(lookup_table_t &tgtPair, lookup_pair_t &lookupPair) {
     std::cerr << "\nCreated paired lookup table" << std::endl;
     std::cerr << " First target string: " << tgtPair[0][0] << " last: " <<
               tgtPair[9][9] << std::endl;
-    std::cerr << " First prior " << lookupPair.priors(1,
-              1) << " last: " << lookupPair.priors(10, 10) << std::endl;
+    std::cerr << " First prior " << lookupPair.priors(0,
+              0) << " last: " << lookupPair.priors(9, 9) << std::endl;
     return 0;
 }
 

--- a/src/include/dng/pedigree.h
+++ b/src/include/dng/pedigree.h
@@ -112,11 +112,11 @@ public:
 protected:
     // node structure:
     // founder germline, non-founder germline, somatic, library
-    std::size_t num_nodes_;        // total number of nodes
-    std::size_t first_founder_;    // start of founder germline
-    std::size_t first_nonfounder_; // start of non-founder germline
-    std::size_t first_somatic_;    // start of somatic nodes
-    std::size_t first_library_;    // start of libraries
+    std::size_t num_nodes_{0};        // total number of nodes
+    std::size_t first_founder_{0};    // start of founder germline
+    std::size_t first_nonfounder_{0}; // start of non-founder germline
+    std::size_t first_somatic_{0};    // start of somatic nodes
+    std::size_t first_library_{0};    // start of libraries
 
     std::vector<std::size_t> roots_;
 

--- a/src/include/dng/task/phaser.xmh
+++ b/src/include/dng/task/phaser.xmh
@@ -27,10 +27,10 @@
  * XM((long)(name), (shortname), "description", typename, defaultvalue)    *
  ***************************************************************************/
 
-XM((dnm), (), "filename: File with list of DNMs to be phased", std::string, "")
-XM((pgt), (), "filename: File with parental genotypes for phasing sites",
+XM((dnm), , "filename: File with list of DNMs to be phased", std::string, "")
+XM((pgt), , "filename: File with parental genotypes for phasing sites",
    std::string, "")
-XM((bam), (), "filename: bam file", std::string, "")
+XM((bam), , "filename: bam file", std::string, "")
 XM((window), (s), "size of window for phasing sites (> insert size)", long,
    1000)
 

--- a/src/lib/call.cc
+++ b/src/lib/call.cc
@@ -414,8 +414,8 @@ int Call::operator()(Call::argument_type &arg) {
         vcfout.AddHeaderMetadata(line.c_str());
     }
 
-    FindMutations calculate { min_prob, pedigree,
-        { arg.theta, freqs, arg.ref_weight, arg.gamma[0], arg.gamma[1] } };
+    FindMutations calculate ( min_prob, pedigree,
+        { arg.theta, freqs, arg.ref_weight, arg.gamma[0], arg.gamma[1] } );
 
     // Pileup data
     std::vector<depth_t> read_depths(rgs.libraries().size());
@@ -877,7 +877,7 @@ int Call::operator()(Call::argument_type &arg) {
 
 FindMutations::FindMutations(double min_prob, const Pedigree &pedigree,
                              params_t params) :
-    pedigree_{pedigree}, min_prob_{min_prob},
+    pedigree_(pedigree), min_prob_(min_prob),
     params_(params), genotype_likelihood_{params.params_a, params.params_b},
     work_(pedigree.CreateWorkspace()) {
 


### PR DESCRIPTION
In some cases, GCC 4.8 creates a temporary when passing a reference to an initializer list.  This causes our FindMutations to have an invalid pedigree_ member.  Change to parentheses notation.

`cmake -DCMAKE_BUILD_TYPE=Debug` also allowed triggered some assertions, and I fixed those issues.
