### PR TITLE
Introduce find_mutation and mutation_stats class and tests.

### DIFF
--- a/src/helpers/find_mutation_helper.cc
+++ b/src/helpers/find_mutation_helper.cc
@@ -1,0 +1,6 @@
+//
+// Created by steven on 1/15/16.
+//
+
+#include "find_mutation_getter.h"
+

--- a/src/helpers/find_mutation_helper.h
+++ b/src/helpers/find_mutation_helper.h
@@ -1,0 +1,83 @@
+//
+// Created by steven on 1/15/16.
+//
+#pragma once
+#ifndef DENOVOGEAR_FIND_MUTATION_GETTER_H
+#define DENOVOGEAR_FIND_MUTATION_GETTER_H
+
+//HACK: I really don't like this hack
+//#define private public
+//#define protected public
+
+#include <dng/find_mutation.h>
+
+
+//Just make testing easier, no real purpose of this class
+class FindMutationsGetter : public FindMutations {
+
+
+public:
+    FindMutationsGetter(double min_prob, const Pedigree &pedigree, const params_t &params) : FindMutations(min_prob,
+                                                                                                           pedigree,
+                                                                                                           params) { }
+public:
+    //TODO, three (more) ways to expose these for testing
+//    double min_prob_ = FindMutations::min_prob_; //HACK: 1
+    using FindMutations::min_prob_; //HACK: 2
+    //getter()
+    double getMin_prob_() const {
+        return min_prob_;
+    }
+
+    const Pedigree &getPedigree_() const {
+        return pedigree_;
+    }
+
+    const params_t &getParams_() const {
+        return params_;
+    }
+
+
+    const peel::workspace_t &getworkspace() const {
+        return work_;
+    }
+
+    const TransitionVector &getFull_transition_matrices_() const {
+        return full_transition_matrices_;
+    }
+
+    const TransitionVector &getNomut_transition_matrices_() const {
+        return nomut_transition_matrices_;
+    }
+
+    const TransitionVector &getPosmut_transition_matrices_() const {
+        return posmut_transition_matrices_;
+    }
+
+    const TransitionVector &getOnemut_transition_matrices_() const {
+        return onemut_transition_matrices_;
+    }
+
+    const TransitionVector &getMean_matrices_() const {
+        return mean_matrices_;
+    }
+
+    const genotype::DirichletMultinomialMixture &getGenotype_likelihood_() const {
+        return genotype_likelihood_;
+    }
+
+    const GenotypeArray *getGenotype_prior_() const {
+        return genotype_prior_;
+    }
+
+    const std::array<double, 5> &getMax_entropies_() const {
+        return max_entropies_;
+    }
+
+    const std::vector<double> &getEvent_() const {
+        return event_;
+    }
+
+};
+
+#endif //DENOVOGEAR_FIND_MUTATION_GETTER_H

--- a/src/include/dng/find_mutation.h
+++ b/src/include/dng/find_mutation.h
@@ -1,0 +1,97 @@
+//
+// Created by steven on 1/11/16.
+//
+
+#pragma once
+#ifndef DENOVOGEAR_FIND_MUTATION_H
+#define DENOVOGEAR_FIND_MUTATION_H
+
+#include <iostream>
+
+#include <dng/hts/bam.h>
+#include <dng/hts/bcf.h>
+#include <dng/pedigree.h>
+#include <dng/likelihood.h>
+#include <dng/mutation.h>
+
+#include "mutation_stats.h"
+
+//using namespace dng::task;
+using namespace dng;
+
+std::vector<std::pair<std::string, uint32_t>> parse_contigs(const bam_hdr_t *hdr);
+
+std::vector<std::string> extract_contigs(const bcf_hdr_t *hdr) ;
+
+class FindMutations {
+public:
+    struct params_t {
+        double theta;
+        std::array<double, 4> nuc_freq;
+        double ref_weight;
+
+        dng::genotype::DirichletMultinomialMixture::params_t params_a;
+        dng::genotype::DirichletMultinomialMixture::params_t params_b;
+    };
+
+    //TODO: replace struct stats_t with mutation_stats.cc
+//    struct [[deprecated]] stats_t {
+    struct stats_t {
+        float mup;
+        float lld;
+        float llh;
+        float mux;
+
+        bool has_single_mut;
+        float mu1p;
+        std::string dnt;
+        std::string dnl;
+        int32_t dnq;
+        int32_t dnc;
+
+        IndividualVector posterior_probabilities;
+        IndividualVector genotype_likelihoods;
+        std::vector<float> node_mup;
+        std::vector<float> node_mu1p;
+    };
+
+    FindMutations(double min_prob, const Pedigree &pedigree, params_t params);
+
+    bool operator()(const std::vector<depth_t> &depths, int ref_index,
+                    stats_t *stats);
+
+    //TODO: either place with this function, or replace operator() with this
+    bool calculate_mutation(const std::vector<depth_t> &depths, int ref_index, MutationStats &mutation_stats);
+
+protected:
+
+    const dng::Pedigree &pedigree_;
+    params_t params_;
+    double min_prob_;
+    dng::peel::workspace_t work_;
+
+    dng::TransitionVector full_transition_matrices_;
+    dng::TransitionVector nomut_transition_matrices_;
+    dng::TransitionVector posmut_transition_matrices_;
+    dng::TransitionVector onemut_transition_matrices_;
+    dng::TransitionVector mean_matrices_;
+
+    // Model genotype likelihoods as a mixture of two dirichlet multinomials
+    // TODO: control these with parameters
+    dng::genotype::DirichletMultinomialMixture genotype_likelihood_;
+
+    dng::GenotypeArray genotype_prior_[5]; // Holds P(G | theta)
+    std::array<double, 5> max_entropies_;
+    std::vector<double> event_;
+
+
+    bool calculate_mutation_prob(MutationStats &stats);
+    void calculate_posterior_probabilities(MutationStats &mutation_stats);
+    void calculate_expected_mutation(MutationStats &mutation_stats);
+    void calculate_node_mutation(MutationStats &mutation_stats);
+    void calculate_denovo_mutation(MutationStats &mutation_stats);
+
+
+};
+
+#endif //DENOVOGEAR_FIND_MUTATION_H

--- a/src/include/dng/graph.h
+++ b/src/include/dng/graph.h
@@ -48,22 +48,22 @@ enum struct EdgeType : std::size_t {
 
 typedef boost::property<boost::vertex_group_t, std::size_t> VertexGroupProp;
 typedef boost::property<boost::vertex_label_t, std::string, VertexGroupProp>
-VertexLabelProp;
+        VertexLabelProp;
 typedef boost::property<boost::edge_family_t, std::size_t> EdgeFamilyProp;
 typedef boost::property<boost::edge_length_t, float, EdgeFamilyProp>
-EdgeLengthProp;
+        EdgeLengthProp;
 typedef boost::property<boost::edge_type_t, EdgeType, EdgeLengthProp>
-EdgeTypeProp;
+        EdgeTypeProp;
 typedef boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS,
         VertexLabelProp, EdgeTypeProp> Graph;
-}
+} // namespace graph
 
 using graph::Graph;
 using graph::EdgeType;
 typedef boost::graph_traits<Graph>::vertex_descriptor vertex_t;
 typedef boost::graph_traits<Graph>::edge_descriptor edge_t;
 
-}
+} // namespace dng
 
 
 #endif // DNG_GRAPH_H

--- a/src/include/dng/mutation.h
+++ b/src/include/dng/mutation.h
@@ -59,6 +59,8 @@ constexpr int mitotic_diploid_mutation_counts[16][16] = {
 extern const char mitotic_diploid_mutation_labels[10][10][6];
 extern const char meiotic_diploid_mutation_labels[100][10][9];
 
+//TODO: Somewhere we need to explain mutype = -1,0,1 -> full, no, one. Maybe enum class?
+
 inline TransitionMatrix mitosis_haploid_matrix(const MutationMatrix &m,
         int mutype = -1) {
     TransitionMatrix ret{4, 4};
@@ -68,6 +70,7 @@ inline TransitionMatrix mitosis_haploid_matrix(const MutationMatrix &m,
                         m(i, j) : 0.0;
         }
     }
+
     return ret; // 4 x 4
 }
 
@@ -229,15 +232,15 @@ inline dng::GenotypeArray population_prior(double theta,
     dng::GenotypeArray ret{10};
     ret <<
         alpha[0]*(1.0 + alpha[0]) / alpha_sum / (1.0 + alpha_sum), // AA
-              2.0 * alpha[0]*(alpha[1]) / alpha_sum / (1.0 + alpha_sum), // AC
-              2.0 * alpha[0]*(alpha[2]) / alpha_sum / (1.0 + alpha_sum), // AG
-              2.0 * alpha[0]*(alpha[3]) / alpha_sum / (1.0 + alpha_sum), // AT
-              alpha[1]*(1.0 + alpha[1]) / alpha_sum / (1.0 + alpha_sum), // CC
-              2.0 * alpha[1]*(alpha[2]) / alpha_sum / (1.0 + alpha_sum), // CG
-              2.0 * alpha[1]*(alpha[3]) / alpha_sum / (1.0 + alpha_sum), // CT
-              alpha[2]*(1.0 + alpha[2]) / alpha_sum / (1.0 + alpha_sum), // GG
-              2.0 * alpha[2]*(alpha[3]) / alpha_sum / (1.0 + alpha_sum), // GT
-              alpha[3]*(1.0 + alpha[3]) / alpha_sum / (1.0 + alpha_sum); // GG
+        2.0 * alpha[0]*(alpha[1]) / alpha_sum / (1.0 + alpha_sum), // AC
+        2.0 * alpha[0]*(alpha[2]) / alpha_sum / (1.0 + alpha_sum), // AG
+        2.0 * alpha[0]*(alpha[3]) / alpha_sum / (1.0 + alpha_sum), // AT
+        alpha[1]*(1.0 + alpha[1]) / alpha_sum / (1.0 + alpha_sum), // CC
+        2.0 * alpha[1]*(alpha[2]) / alpha_sum / (1.0 + alpha_sum), // CG
+        2.0 * alpha[1]*(alpha[3]) / alpha_sum / (1.0 + alpha_sum), // CT
+        alpha[2]*(1.0 + alpha[2]) / alpha_sum / (1.0 + alpha_sum), // GG
+        2.0 * alpha[2]*(alpha[3]) / alpha_sum / (1.0 + alpha_sum), // GT
+        alpha[3]*(1.0 + alpha[3]) / alpha_sum / (1.0 + alpha_sum); // GG
     return ret;
 }
 

--- a/src/include/dng/mutation_stats.h
+++ b/src/include/dng/mutation_stats.h
@@ -1,0 +1,105 @@
+//
+// Created by steven on 2/3/16.
+//
+
+#ifndef DENOVOGEAR_MUTATION_STATS_H
+#define DENOVOGEAR_MUTATION_STATS_H
+
+#include <string>
+#include <vector>
+
+#include <dng/matrix.h>
+#include <dng/peeling.h>
+#include <dng/hts/bcf.h>
+
+class MutationStats {
+
+public:
+
+    MutationStats(double min_prob);
+
+    float get_mutation_prob() const;
+
+    bool get_has_single_mut() const;
+
+    const dng::GenotypeArray &inspect_posterior_at(int index) const;
+
+    const dng::GenotypeArray &inspect_genotype_at(int index) const;
+
+
+    bool set_mutation_prob(const double logdata_nomut, const double logdata);
+
+    void set_scaled_log_likelihood(double scale);
+
+    void set_genotype_likelihood(const dng::peel::workspace_t &workspace, const int depth_size);
+
+    void set_posterior_probabilities(const dng::peel::workspace_t &workspace);
+
+    void set_exactly_one_mutation(double total);
+
+    void set_node_mup(const std::vector<double> &event, std::size_t first_nonfounder_index);
+
+    void set_node_mu1p(std::vector<double> &event, double total, std::size_t first_nonfounder_index);
+
+
+
+    void record_basic_stats(hts::bcf::Variant &record);
+
+    void record_genotype_stats(hts::bcf::Variant &record);
+
+    void record_single_mutation_stats(hts::bcf::Variant &record);
+
+
+    enum class OutputLevel {BASIC, COMPLETE, SINGLE};
+    //TODO: Record different sets of variables, [basic, complete, everytihng/single], something like the following
+    //basic [ mup, lld, llh, genotype_likelihood]?
+    //complete [basic, mux, posterior, node_mup]
+    //single [complete, has_single_mut, mu1p, dnt, dnl, dnq, dnc, node_mu1p]
+
+
+
+    void set_genotype_related_stats(const int (&acgt_to_refalt_allele)[5],
+                                                   const int (&refalt_to_acgt_allele)[5],
+                                                   const uint32_t n_alleles,
+                                                   const std::size_t ref_index,
+                                                   const std::size_t num_nodes,
+                                                   const std::size_t library_start);
+
+
+
+private://TODO: surely these should not be public. Refactor these while working with call.cc
+public:
+    float mup;
+    float lld;
+    float llh;
+    float mux;
+
+    bool has_single_mut;
+    float mu1p;
+
+    std::string dnt;
+    std::string dnl;
+    int32_t dnq;
+    [[deprecated]] int32_t dnc;
+
+    dng::IndividualVector posterior_probabilities;
+    dng::IndividualVector genotype_likelihoods;
+    std::vector<float> node_mup;
+    std::vector<float> node_mu1p;
+
+    std::vector<int32_t> best_genotypes;//.resize(2 * num_nodes);
+    std::vector<int32_t> genotype_qualities;//(num_nodes);
+    std::vector<float> gp_scores;//(gt_count*num_nodes );
+    std::vector<float> gl_scores;//(gt_count *num_nodes, hts::bcf::float_missing);
+
+private:
+
+    double min_prob;
+    double logdata;//TODO: Maybe hack these away, using lld, llh
+    double logdata_nomut;
+
+    void set_node_core(std::vector<float> &stats, const std::vector<double> &event,
+                       std::size_t first_nonfounder_index);
+
+};
+#endif //DENOVOGEAR_MUTATION_STATS_H

--- a/src/include/utils/assert_utils.h
+++ b/src/include/utils/assert_utils.h
@@ -1,0 +1,70 @@
+//
+// Created by steven on 1/29/16.
+//
+
+#ifndef DENOVOGEAR_ASSERT_UTILS_H
+#define DENOVOGEAR_ASSERT_UTILS_H
+
+#include <cassert>
+
+
+const double ASSERT_CLOSE_THRESHOLD = 1e-6;
+
+//TODO: HACK: FIXME:
+template<typename A, typename B>
+void AssertEqual(A expected, B actual) {
+    assert(expected == actual);
+};
+
+template<typename A>
+void AssertEqual(A expected, A actual) {
+    assert(expected == actual);
+};
+
+template<typename A>
+void AssertNear(A expected, A actual) {
+    if (!(expected == 0 && actual == 0)) {
+        assert(((expected - actual) / expected) < ASSERT_CLOSE_THRESHOLD);
+    }
+
+};
+
+//template<typename A>
+//void AssertVectorNear(A expected, A actual){
+//    AssertEqual(expected.size(), actual.size());
+//    for (int j = 0; j < expected.size(); ++j) {
+//        AssertNear(expected[j], actual[j]);
+//    }
+//};
+
+template<typename A, typename B>
+void AssertVectorEqual(A expected, B actual) {
+    AssertEqual(expected.size(), actual.size());
+    for (int j = 0; j < expected.size(); ++j) {
+        AssertEqual(expected[j], actual[j]);
+    }
+};
+
+
+template<typename A, typename B>
+void AssertVectorNear(A expected, B actual) {
+    AssertEqual(expected.size(), actual.size());
+    for (int j = 0; j < expected.size(); ++j) {
+        AssertNear(expected[j], actual[j]);
+    }
+};
+
+
+template<typename A>
+void AssertEigenMatrixNear(A expected, A actual) {
+    AssertEqual(expected.rows(), actual.rows());
+    AssertEqual(expected.cols(), actual.cols());
+    for (int j = 0; j < expected.rows(); ++j) {
+        for (int k = 0; k < expected.cols(); ++k) {
+            AssertNear(expected(j, k), actual(j, k));
+        }
+    }
+}
+
+
+#endif //DENOVOGEAR_ASSERT_UTILS_H

--- a/src/include/utils/assert_utils.h
+++ b/src/include/utils/assert_utils.h
@@ -10,60 +10,69 @@
 
 const double ASSERT_CLOSE_THRESHOLD = 1e-6;
 
+
 //TODO: HACK: FIXME:
 template<typename A, typename B>
-void AssertEqual(A expected, B actual) {
+void assert_equal(A expected, B actual) {
     assert(expected == actual);
 };
 
 template<typename A>
-void AssertEqual(A expected, A actual) {
+void assert_equal(A expected, A actual) {
     assert(expected == actual);
 };
 
 template<typename A>
-void AssertNear(A expected, A actual) {
+void assert_near(A expected, A actual) {
+
+#ifndef	NDEBUG
     if (!(expected == 0 && actual == 0)) {
         assert(((expected - actual) / expected) < ASSERT_CLOSE_THRESHOLD);
     }
-
+#endif
 };
 
 //template<typename A>
 //void AssertVectorNear(A expected, A actual){
-//    AssertEqual(expected.size(), actual.size());
+//    assert_equal(expected.size(), actual.size());
 //    for (int j = 0; j < expected.size(); ++j) {
 //        AssertNear(expected[j], actual[j]);
 //    }
 //};
 
 template<typename A, typename B>
-void AssertVectorEqual(A expected, B actual) {
-    AssertEqual(expected.size(), actual.size());
+void assert_equal_vector(A expected, B actual) {
+#ifndef	NDEBUG
+    assert_equal(expected.size(), actual.size());
     for (int j = 0; j < expected.size(); ++j) {
-        AssertEqual(expected[j], actual[j]);
+        assert_equal(expected[j], actual[j]);
     }
+#endif
 };
 
 
 template<typename A, typename B>
-void AssertVectorNear(A expected, B actual) {
-    AssertEqual(expected.size(), actual.size());
+void assert_near_vector(A expected, B actual) {
+#ifndef	NDEBUG
+    assert_equal(expected.size(), actual.size());
     for (int j = 0; j < expected.size(); ++j) {
-        AssertNear(expected[j], actual[j]);
+        assert_near(expected[j], actual[j]);
     }
+#endif
 };
 
 
 template<typename A>
-void AssertEigenMatrixNear(A expected, A actual) {
-    AssertEqual(expected.rows(), actual.rows());
-    AssertEqual(expected.cols(), actual.cols());
+void assert_near_eigen_matrix(A expected, A actual) {
+#ifndef	NDEBUG
+    assert_equal(expected.rows(), actual.rows());
+    assert_equal(expected.cols(), actual.cols());
     for (int j = 0; j < expected.rows(); ++j) {
         for (int k = 0; k < expected.cols(); ++k) {
-            AssertNear(expected(j, k), actual(j, k));
+            assert_near(expected(j, k), actual(j, k));
         }
     }
+#endif
 }
 
 

--- a/src/include/utils/boost_utils.h
+++ b/src/include/utils/boost_utils.h
@@ -5,6 +5,7 @@
 #ifndef DENOVOGEAR_BOOST_UTILS_H
 #define DENOVOGEAR_BOOST_UTILS_H
 
+#include <boost/range/iterator_range_core.hpp>
 namespace utils {
 
 

--- a/src/include/utils/boost_utils.h
+++ b/src/include/utils/boost_utils.h
@@ -1,0 +1,23 @@
+//
+// Created by steven on 2/4/16.
+//
+
+#ifndef DENOVOGEAR_BOOST_UTILS_H
+#define DENOVOGEAR_BOOST_UTILS_H
+
+namespace utils {
+
+
+// Helper function that mimics boost::istream_range
+template<class Elem, class Traits> inline
+boost::iterator_range <std::istreambuf_iterator<Elem, Traits>> istreambuf_range(
+        std::basic_istream <Elem, Traits> &in) {
+    return boost::iterator_range < std::istreambuf_iterator < Elem, Traits >> (
+            std::istreambuf_iterator<Elem, Traits>(in),
+                    std::istreambuf_iterator<Elem, Traits>());
+}
+
+
+} // namespace utils
+
+#endif //DENOVOGEAR_BOOST_UTILS_H

--- a/src/include/utils/vcf_utils.h
+++ b/src/include/utils/vcf_utils.h
@@ -1,0 +1,177 @@
+//
+// Created by steven on 1/11/16.
+//
+
+#ifndef DENOVOGEAR_VCF_HELPER_H
+#define DENOVOGEAR_VCF_HELPER_H
+
+
+/*
+ * Copyright (c) 2014-2015 Reed A. Cartwright
+ * Copyright (c) 2015 Kael Dai
+ * Authors:  Reed A. Cartwright <reed@cartwrig.ht>
+ *           Kael Dai <kdai1@asu.edu>
+ *
+ * This file is part of DeNovoGear.
+ *
+ * DeNovoGear is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <cstdlib>
+#include <fstream>
+#include <iterator>
+#include <iosfwd>
+
+#include <iostream>
+#include <iomanip>
+#include <ctime>
+#include <chrono>
+#include <sstream>
+#include <string>
+
+#include <boost/range/iterator_range.hpp>
+#include <boost/range/algorithm/replace.hpp>
+#include <boost/range/algorithm/max_element.hpp>
+
+#include <boost/algorithm/string.hpp>
+
+#include <dng/task/call.h>
+#include <dng/pedigree.h>
+#include <dng/fileio.h>
+#include <dng/pileup.h>
+#include <dng/read_group.h>
+#include <dng/likelihood.h>
+#include <dng/seq.h>
+#include <dng/utilities.h>
+#include <dng/hts/bcf.h>
+#include <dng/hts/extra.h>
+#include <dng/vcfpileup.h>
+#include <dng/mutation.h>
+#include <dng/stats.h>
+
+#include <htslib/faidx.h>
+#include <htslib/khash.h>
+
+#include "version.h"
+
+using namespace dng::task;
+using namespace dng;
+
+
+
+// Helper function to determines if output should be bcf file, vcf file, or stdout. Also
+// parses filename "bcf:<file>" --> "<file>"
+std::pair<std::string, std::string> vcf_get_output_mode(
+        Call::argument_type &arg) {
+    using boost::algorithm::iequals;
+
+    if(arg.output.empty() || arg.output == "-")
+        return {"-", "w"};
+    auto ret = hts::extra::extract_file_type(arg.output);
+    if(iequals(ret.first, "bcf")) {
+        return {ret.second, "wb"};
+    } else if(iequals(ret.first, "vcf")) {
+        return {ret.second, "w"};
+    } else {
+        throw std::runtime_error("Unknown file format '" + ret.second + "' for output '"
+                                 + arg.output + "'.");
+    }
+    return {};
+}
+
+std::string vcf_timestamp() {
+    using namespace std;
+    using namespace std::chrono;
+    std::string buffer(127, '\0');
+    auto now = system_clock::now();
+    auto now_t = system_clock::to_time_t(now);
+    size_t sz = strftime(&buffer[0], 127, "Date=\"%FT%T%z\",Epoch=",
+                         localtime(&now_t));
+    buffer.resize(sz);
+    auto epoch = std::chrono::duration_cast<std::chrono::milliseconds>(
+            now.time_since_epoch());
+    buffer += to_string(epoch.count());
+    return buffer;
+}
+
+template<typename V, typename A>
+std::string vcf_command_line_text(const char *arg,
+                                  const std::vector<V, A> &val) {
+    std::string str;
+    for(auto && a : val) {
+        str += std::string("--") + arg + '=' + dng::util::to_pretty(a) + ' ';
+    }
+    str.pop_back();
+    return str;
+}
+
+
+template<typename VAL>
+std::string vcf_command_line_text(const char *arg, VAL val) {
+    return std::string("--") + arg + '=' + dng::util::to_pretty(val);
+}
+
+std::string vcf_command_line_text(const char *arg, std::string val) {
+    return std::string("--") + arg + "=\'" + val + "\'";
+}
+
+// Helper function for writing the vcf header information
+void vcf_add_header_text(hts::bcf::File &vcfout, Call::argument_type &arg) {
+    using namespace std;
+    string line{"##DeNovoGearCommandLine=<ID=dng-call,Version="
+            PACKAGE_VERSION ","};
+    line += vcf_timestamp();
+    line += ",CommandLineOptions=\"";
+
+#define XM(lname, sname, desc, type, def) \
+	line += vcf_command_line_text(XS(lname),arg.XV(lname)) + ' ';
+#	include <dng/task/call.xmh>
+#undef XM
+    for(auto && a : arg.input) {
+        line += a + ' ';
+    }
+
+    line.pop_back();
+    line += "\">";
+    vcfout.AddHeaderMetadata(line);
+
+    // Add the available tags for INFO, FILTER, and FORMAT fields
+    vcfout.AddHeaderMetadata("##INFO=<ID=MUP,Number=1,Type=Float,Description=\"Probability of at least 1 de novo mutation\">");
+    vcfout.AddHeaderMetadata("##INFO=<ID=MU1P,Number=1,Type=Float,Description=\"Probability of exactly 1 de novo mutation\">");
+    vcfout.AddHeaderMetadata("##INFO=<ID=MUX,Number=1,Type=Float,Description=\"Expected number of de novo mutations\">");
+    vcfout.AddHeaderMetadata("##INFO=<ID=LLD,Number=1,Type=Float,Description=\"Log10-likelihood of observed data at the site\">");
+    vcfout.AddHeaderMetadata("##INFO=<ID=LLH,Number=1,Type=Float,Description=\"Scaled log10-likelihood of data at the site\">");
+    vcfout.AddHeaderMetadata("##INFO=<ID=DNT,Number=1,Type=String,Description=\"De novo type\">");
+    vcfout.AddHeaderMetadata("##INFO=<ID=DNL,Number=1,Type=String,Description=\"De novo location\">");
+    vcfout.AddHeaderMetadata("##INFO=<ID=DNQ,Number=1,Type=Integer,Description=\"Phread-scaled de novo quality\">");
+    vcfout.AddHeaderMetadata("##INFO=<ID=DNC,Number=1,Type=Integer,Description=\"De novo location certainty\">");
+    vcfout.AddHeaderMetadata("##INFO=<ID=DP,Number=1,Type=Integer,Description=\"Total depth\">");
+    vcfout.AddHeaderMetadata("##INFO=<ID=AD,Number=R,Type=Integer,Description=\"Allelic depths for the ref and alt alleles in the order listed\">");
+    vcfout.AddHeaderMetadata("##INFO=<ID=ADF,Number=R,Type=Integer,Description=\"Allelic depths for the ref and alt alleles in the order listed (forward strand)\">");
+    vcfout.AddHeaderMetadata("##INFO=<ID=ADR,Number=R,Type=Integer,Description=\"Allelic depths for the ref and alt alleles in the order listed (reverse strand)\">");
+    vcfout.AddHeaderMetadata("##INFO=<ID=FS,Number=1,Type=Float,Description=\"Phred-scaled p-value using Fisher's exact test to detect strand bias\">");
+    vcfout.AddHeaderMetadata("##INFO=<ID=MQTa,Number=1,Type=Float,Description=\"Anderson-Darling Ta statistic for Alt vs. Ref read mapping qualities\">");
+
+    vcfout.AddHeaderMetadata("##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">");
+    vcfout.AddHeaderMetadata("##FORMAT=<ID=GQ,Number=1,Type=Integer,Description=\"Phred-scaled genotype quality\">");
+    vcfout.AddHeaderMetadata("##FORMAT=<ID=GP,Number=G,Type=Float,Description=\"Genotype posterior probabilities\">");
+    vcfout.AddHeaderMetadata("##FORMAT=<ID=GL,Number=G,Type=Float,Description=\"Log10-likelihood of genotype based on read depths\">");
+    vcfout.AddHeaderMetadata("##FORMAT=<ID=DP,Number=1,Type=Integer,Description=\"Read depth\">");
+    vcfout.AddHeaderMetadata("##FORMAT=<ID=AD,Number=R,Type=Integer,Description=\"Allelic depths for the ref and alt alleles in the order listed\">");
+    vcfout.AddHeaderMetadata("##FORMAT=<ID=ADF,Number=R,Type=Integer,Description=\"Allelic depths for the ref and alt alleles in the order listed (forward strand)\">");
+    vcfout.AddHeaderMetadata("##FORMAT=<ID=ADR,Number=R,Type=Integer,Description=\"Allelic depths for the ref and alt alleles in the order listed (reverse strand)\">");
+    vcfout.AddHeaderMetadata("##FORMAT=<ID=MUP,Number=1,Type=Float,Description=\"Probability of at least 1 de novo mutation in this node.\">");
+    vcfout.AddHeaderMetadata("##FORMAT=<ID=MU1P,Number=1,Type=Float,Description=\"Conditional probability that this node contains a de novo mutation given only 1 de novo mutation\">");
+}
+
+#endif //DENOVOGEAR_VCF_HELPER_H

--- a/src/lib/call.cc
+++ b/src/lib/call.cc
@@ -172,7 +172,7 @@ void vcf_add_header_text(hts::bcf::File &vcfout, Call::argument_type &arg) {
     vcfout.AddHeaderMetadata("##FORMAT=<ID=MUP,Number=1,Type=Float,Description=\"Probability of at least 1 de novo mutation in this node.\">");
     vcfout.AddHeaderMetadata("##FORMAT=<ID=MU1P,Number=1,Type=Float,Description=\"Conditional probability that this node contains a de novo mutation given only 1 de novo mutation\">");
 }
-
+//TODO: In the process of moving this class to find_mutations.cc
 class FindMutations {
 public:
     struct params_t {
@@ -746,6 +746,10 @@ int Call::operator()(Call::argument_type &arg) {
             if(!calculate(read_depths, ref_index, &stats)) {
                 return;
             }
+//TODO: Replace the if(!caluclate...) with the following
+//            MutationStats mutation_stats (min_prob);
+//            calculate.calculate_mutation(read_depths, ref_index, mutation_stats);
+
 
             // reformatted AD fields for output. The first few fields are the GL and SM fields and "AD" is missing. The
             // remaining fields are just copied from the input file
@@ -771,6 +775,10 @@ int Call::operator()(Call::argument_type &arg) {
 
             // Update REF, ALT fields
             record.alleles(allele_order_str);
+//TODO: replace the calculation with set_genotype_related_stats(). This will work for both sequence/variant_data
+//mutation_stats.set_genotype_related_stats(acgt_to_refalt_allele, refalt_to_acgt_allele, n_alleles,
+//                                          ref_index, num_nodes, library_start);
+
 
             typedef pair<int, int> key_t;
             key_t total_depths[4] = {{0, 0}, {1, 0}, {2, 0}, {3, 0}};
@@ -834,6 +842,13 @@ int Call::operator()(Call::argument_type &arg) {
                                      stats.genotype_likelihoods[i][n];
                 }
             }
+
+//mutation_stats.record_basic_stats(record);//TODO: replace with this
+//mutation_stats.record_genotype_stats(record);//TODO: replace with this
+//mutation_stats.record_single_mutation_stats(record); //TODO: replace with this
+
+
+
 
 
             record.info("MUP", stats.mup);

--- a/src/lib/find_mutation.cc
+++ b/src/lib/find_mutation.cc
@@ -1,0 +1,440 @@
+//
+// Created by steven on 2/3/16.
+//
+
+#define CALCULATE_ENTROPY false
+
+#include <dng/find_mutation.h>
+
+
+// Build a list of all of the possible contigs to add to the vcf header
+std::vector<std::pair<std::string, uint32_t>> parse_contigs(const bam_hdr_t *hdr) {
+    if(hdr == nullptr)
+        return {};
+    std::vector<std::pair<std::string, uint32_t>> contigs;
+    uint32_t n_targets = hdr->n_targets;
+    for(size_t a = 0; a < n_targets; a++) {
+        if(hdr->target_name[a] == nullptr) {
+            continue;
+        }
+        contigs.emplace_back(hdr->target_name[a], hdr->target_len[a]);
+    }
+    return contigs;
+}
+
+
+// VCF header lacks a function to get sequence lengths
+// So we will extract the contig lines from the input header
+std::vector<std::string> extract_contigs(const bcf_hdr_t *hdr) {
+    if(hdr == nullptr)
+        return {};
+    // Read text of header
+    int len;
+    std::unique_ptr<char[], void(*)(void *)> str{bcf_hdr_fmt_text(hdr, 0, &len), free};
+    if(!str)
+        return {};
+    std::vector<std::string> contigs;
+
+    // parse ##contig lines
+    const char *text = str.get();
+    if(strncmp(text, "##contig=", 9) != 0) {
+        text = strstr(text, "\n##contig=");
+    } else {
+        text = text - 1;
+    }
+    const char *end;
+    for(; text != nullptr; text = strstr(end, "\n##contig=")) {
+        for(end = text + 10; *end != '\n' && *end != '\0'; ++end)
+            /*noop*/;
+        if(*end != '\n') {
+            return contigs;    // bad header, return what we have.
+        }
+        contigs.emplace_back(text + 1, end);
+    }
+
+    return contigs;
+}
+
+
+//TODO: eventually min_prob can be removed from this class
+FindMutations::FindMutations(double min_prob, const Pedigree &pedigree,
+                             params_t params) :
+        pedigree_{pedigree}, min_prob_{min_prob},
+        params_(params), genotype_likelihood_{params.params_a, params.params_b},
+        work_(pedigree.CreateWorkspace()) {
+
+    using namespace dng;
+
+    // Use a parent-independent mutation model, which produces a
+    // beta-binomial
+    genotype_prior_[0] = population_prior(params_.theta, params_.nuc_freq, {params_.ref_weight, 0, 0, 0});
+    genotype_prior_[1] = population_prior(params_.theta, params_.nuc_freq, {0, params_.ref_weight, 0, 0});
+    genotype_prior_[2] = population_prior(params_.theta, params_.nuc_freq, {0, 0, params_.ref_weight, 0});
+    genotype_prior_[3] = population_prior(params_.theta, params_.nuc_freq, {0, 0, 0, params_.ref_weight});
+    genotype_prior_[4] = population_prior(params_.theta, params_.nuc_freq, {0, 0, 0, 0});
+
+    // Calculate mutation expectation matrices
+    full_transition_matrices_.assign(work_.num_nodes, {});
+    nomut_transition_matrices_.assign(work_.num_nodes, {});
+    posmut_transition_matrices_.assign(work_.num_nodes, {});
+    onemut_transition_matrices_.assign(work_.num_nodes, {});
+    mean_matrices_.assign(work_.num_nodes, {});
+
+    for(size_t child = 0; child < work_.num_nodes; ++child) {
+
+        auto trans = pedigree.transitions()[child];
+//        std::cout << "Node:" << child << "\t" << "\t" << trans.length1 << "\t" << trans.length2 <<
+//                "\tType:" << (int) trans.type << std::endl;
+
+        if(trans.type == Pedigree::TransitionType::Germline) {
+            auto dad = f81::matrix(trans.length1, params_.nuc_freq);
+            auto mom = f81::matrix(trans.length2, params_.nuc_freq);
+
+            full_transition_matrices_[child] = meiosis_diploid_matrix(dad, mom);
+            nomut_transition_matrices_[child] = meiosis_diploid_matrix(dad, mom, 0);
+            posmut_transition_matrices_[child] = full_transition_matrices_[child] -
+                                                 nomut_transition_matrices_[child];
+            onemut_transition_matrices_[child] = meiosis_diploid_matrix(dad, mom, 1);
+            mean_matrices_[child] = meiosis_diploid_mean_matrix(dad, mom);
+        } else if(trans.type == Pedigree::TransitionType::Somatic ||
+                  trans.type == Pedigree::TransitionType::Library) {
+            auto orig = f81::matrix(trans.length1, params_.nuc_freq);
+
+            full_transition_matrices_[child] = mitosis_diploid_matrix(orig);
+            nomut_transition_matrices_[child] = mitosis_diploid_matrix(orig, 0);
+            posmut_transition_matrices_[child] = full_transition_matrices_[child] -
+                                                 nomut_transition_matrices_[child];
+            onemut_transition_matrices_[child] = mitosis_diploid_matrix(orig, 1);
+            mean_matrices_[child] = mitosis_diploid_mean_matrix(orig);
+        } else {
+            full_transition_matrices_[child] = {};
+            nomut_transition_matrices_[child] = {};
+            posmut_transition_matrices_[child] = {};
+            onemut_transition_matrices_[child] = {};
+            mean_matrices_[child] = {};
+        }
+
+    }
+
+#if CALCULATE_ENTROPY == true
+    //Calculate max_entropy based on having no data
+    for(int ref_index = 0; ref_index < 5; ++ref_index) {
+        work_.SetFounders(genotype_prior_[ref_index]);
+
+        pedigree_.PeelForwards(work_, nomut_transition_matrices_);
+        pedigree_.PeelBackwards(work_, nomut_transition_matrices_);
+        event_.assign(work_.num_nodes, 0.0);
+        double total = 0.0, entropy = 0.0;
+        for(std::size_t i = work_.founder_nodes.second; i < work_.num_nodes; ++i) {
+            Eigen::ArrayXXd mat = (work_.super[i].matrix() *
+                                   work_.lower[i].matrix().transpose()).array() *
+                                  onemut_transition_matrices_[i].array();
+            total += mat.sum();
+            entropy += (mat.array() == 0.0).select(mat.array(),
+                                                   mat.array() * mat.log()).sum();
+        }
+        // Calculate entropy of mutation location
+        max_entropies_[ref_index] = (-entropy / total + log(total)) / M_LN2;
+    }
+#endif
+
+//    std::cout << "END FM const" << std::endl;
+
+
+}
+
+// Returns true if a mutation was found and the record was modified
+bool FindMutations::operator()(const std::vector<depth_t> &depths,
+                               int ref_index, stats_t *stats) {
+    using namespace std;
+    using namespace hts::bcf;
+    using dng::util::lphred;
+    using dng::util::phred;
+
+
+    std::cout << "FM() depth: " << "\t" << depths.size() << std::endl;
+    for (auto d : depths) {
+        auto cc = d.counts;
+        std::cout << cc[0] << " "<< cc[1] << " "<< cc[2] << " "<< cc[3] << " "<< std::endl;
+    }
+    MutationStats mutation_stats(min_prob_);
+
+    assert(stats != nullptr);
+
+    // calculate genotype likelihoods and store in the lower library vector
+    double scale = 0.0, stemp;
+    for(std::size_t u = 0; u < depths.size(); ++u) {
+        std::tie(work_.lower[work_.library_nodes.first + u], stemp) =
+                genotype_likelihood_(depths[u], ref_index);
+        scale += stemp;
+    }
+
+    // Set the prior probability of the founders given the reference
+    work_.SetFounders(genotype_prior_[ref_index]);
+
+    // Calculate log P(Data, nomut ; model)
+    const double logdata_nomut = pedigree_.PeelForwards(work_,
+                                                        nomut_transition_matrices_);
+
+    /**** Forward-Backwards with full-mutation ****/
+
+    // Calculate log P(Data ; model)
+    const double logdata = pedigree_.PeelForwards(work_, full_transition_matrices_);
+
+    // P(mutation | Data ; model) = 1 - [ P(Data, nomut ; model) / P(Data ; model) ]
+    const double pmut = -std::expm1(logdata_nomut - logdata);
+
+
+    std::cout << logdata_nomut << "\t" << logdata << "\t" << pmut << "\t" << min_prob_ << std::endl;
+    mutation_stats.set_mutation_prob(logdata_nomut, logdata);
+
+    // Skip this site if it does not meet lower probability threshold
+    if(pmut < min_prob_) {
+        return false;
+    }
+
+    // Copy genotype likelihoods
+    stats->genotype_likelihoods.resize(work_.num_nodes);
+    for(std::size_t u = 0; u < depths.size(); ++u) {
+        std::size_t pos = work_.library_nodes.first + u;
+        stats->genotype_likelihoods[pos] = work_.lower[pos].log() / M_LN10;
+    }
+
+    // Peel Backwards with full-mutation
+    std::cout << "Peel Backwards with full-mutation" << std::endl;
+    pedigree_.PeelBackwards(work_, full_transition_matrices_);
+
+//    size_t library_start = work_.library_nodes.first; //TODO: Can delete this??
+    std::cout << "Copy Genotype likelihood" << std::endl;
+    mutation_stats.set_genotype_likelihood(work_, depths.size());
+    mutation_stats.set_scaled_log_likelihood(scale);
+
+    stats->mup = pmut;
+    stats->lld = (logdata + scale) / M_LN10;
+    stats->llh = logdata / M_LN10;
+
+    // Calculate statistics after Forward-Backwards
+    stats->posterior_probabilities.resize(work_.num_nodes);
+    for(std::size_t i = 0; i < work_.num_nodes; ++i) {
+        stats->posterior_probabilities[i] = work_.upper[i] * work_.lower[i];
+        stats->posterior_probabilities[i] /= stats->posterior_probabilities[i].sum();
+    }
+
+    std::cout << "Mux and node_mup[i]" << std::endl;
+    double mux = 0.0;
+    event_.assign(work_.num_nodes, 0.0);
+    for(std::size_t i = work_.founder_nodes.second; i < work_.num_nodes; ++i) {
+        mux += (work_.super[i] * (mean_matrices_[i] *
+                                  work_.lower[i].matrix()).array()).sum();
+        event_[i] = (work_.super[i] * (posmut_transition_matrices_[i] *
+                                       work_.lower[i].matrix()).array()).sum();
+        event_[i] = event_[i] / pmut;
+    }
+    stats->mux = mux;
+
+    stats->node_mup.resize(work_.num_nodes, hts::bcf::float_missing);
+    for(size_t i = work_.founder_nodes.second; i < work_.num_nodes; ++i) {
+        stats->node_mup[i] = static_cast<float>(event_[i]);
+    }
+
+    /**** Forward-Backwards with no-mutation ****/
+
+    // TODO: Better to use a separate workspace???
+    pedigree_.PeelForwards(work_, nomut_transition_matrices_);
+    pedigree_.PeelBackwards(work_, nomut_transition_matrices_);
+    event_.assign(work_.num_nodes, 0.0);
+    double total = 0.0, entropy = 0.0, max_coeff = -1.0;
+    size_t dn_loc = 0, dn_col = 0, dn_row = 0;
+    for(std::size_t i = work_.founder_nodes.second; i < work_.num_nodes; ++i) {
+        Eigen::ArrayXXd mat = (work_.super[i].matrix() *
+                               work_.lower[i].matrix().transpose()).array() *
+                              onemut_transition_matrices_[i].array();
+        std::size_t row, col;
+        double mat_max = mat.maxCoeff(&row, &col);
+        if(mat_max > max_coeff) {
+            max_coeff = mat_max;
+            dn_row  = row;
+            dn_col = col;
+            dn_loc = i;
+        }
+        event_[i] = mat.sum();
+        entropy += (mat.array() == 0.0).select(mat.array(),
+                                               mat.array() * mat.log()).sum();
+        total += event_[i];
+    }
+    // Calculate P(only 1 mutation)
+    const double pmut1 = total * (1.0 - pmut);
+    stats->mu1p = pmut1;
+
+    // Output statistics for single mutation only if it is likely
+    if(pmut1 / pmut >= min_prob_) {
+        stats->has_single_mut = true;
+        for(std::size_t i = work_.founder_nodes.second; i < work_.num_nodes; ++i) {
+            event_[i] = event_[i] / total;
+        }
+
+        // Calculate entropy of mutation location
+        entropy = (-entropy / total + log(total)) / M_LN2;
+        entropy /= max_entropies_[ref_index];
+        stats->dnc = std::round(100.0 * (1.0 - entropy));
+
+        stats->dnq = lphred<int32_t>(1.0 - (max_coeff / total), 255);
+        stats->dnl = pedigree_.labels()[dn_loc];
+        if(pedigree_.transitions()[dn_loc].type == Pedigree::TransitionType::Germline) {
+            stats->dnt = &meiotic_diploid_mutation_labels[dn_row][dn_col][0];
+        } else {
+            stats->dnt = &mitotic_diploid_mutation_labels[dn_row][dn_col][0];
+        }
+
+        stats->node_mu1p.resize(work_.num_nodes, hts::bcf::float_missing);
+        for(size_t i = work_.founder_nodes.second; i < work_.num_nodes; ++i) {
+            stats->node_mu1p[i] = static_cast<float>(event_[i]);
+        }
+    } else {
+        stats->has_single_mut = false;
+    }
+    return true;
+}
+
+
+// Returns true if a mutation was found and the record was modified
+bool FindMutations::calculate_mutation(const std::vector<depth_t> &depths,
+                               int ref_index, MutationStats &mutation_stats) {
+
+    double scale = work_.set_genotype_likelihood(genotype_likelihood_, depths, ref_index);
+
+    // Set the prior probability of the founders given the reference
+    work_.SetFounders(genotype_prior_[ref_index]);
+
+    bool is_mup_lt_threshold = calculate_mutation_prob(mutation_stats);
+    if(is_mup_lt_threshold ){
+        return false;
+    }
+
+    mutation_stats.set_scaled_log_likelihood(scale);
+    mutation_stats.set_genotype_likelihood(work_, depths.size());
+
+
+    // Peel Backwards with full-mutation
+//    std::cout << "Peel Backwards with full-mutation" << std::endl;
+    pedigree_.PeelBackwards(work_, full_transition_matrices_);
+    mutation_stats.set_posterior_probabilities(work_);
+//    calculate_posterior_probabilities(mutation_stats);
+
+//    std::cout << "Mux expected number of mutation and node_mup[i]" << std::endl;
+    calculate_expected_mutation(mutation_stats);
+    calculate_node_mutation(mutation_stats);
+
+    calculate_denovo_mutation(mutation_stats);
+
+
+    return true;
+
+}
+
+bool FindMutations::calculate_mutation_prob(MutationStats &mutation_stats) {
+    // Calculate log P(Data, nomut ; model)
+    const double logdata_nomut = pedigree_.PeelForwards(work_, nomut_transition_matrices_);
+
+    /**** Forward-Backwards with full-mutation ****/
+    // Calculate log P(Data ; model)
+    const double logdata = pedigree_.PeelForwards(work_, full_transition_matrices_);
+
+    // P(mutation | Data ; model) = 1 - [ P(Data, nomut ; model) / P(Data ; model) ]
+    bool is_mup_lt_threshold = mutation_stats.set_mutation_prob(logdata_nomut, logdata);
+
+    return is_mup_lt_threshold;
+}
+
+
+//void FindMutations::calculate_posterior_probabilities(MutationStats &mutation_stats) {
+//    //TODO: PeelBackwards can NOT call twice, maybe not a good idea to put here
+//    pedigree_.PeelBackwards(work_, full_transition_matrices_);
+//    mutation_stats.set_posterior_probabilities(work_);
+//
+//}
+
+
+void FindMutations::calculate_expected_mutation(MutationStats &mutation_stats) {
+    double mux = 0.0;
+    for(size_t i = work_.founder_nodes.second; i < work_.num_nodes; ++i) {
+        mux += (work_.super[i] * (mean_matrices_[i] *
+                                  work_.lower[i].matrix()).array()).sum();
+    }
+    mutation_stats.mux = mux;
+
+}
+
+void FindMutations::calculate_node_mutation(MutationStats &mutation_stats) {
+
+    event_.assign(work_.num_nodes, 0.0);
+    for(size_t i = work_.founder_nodes.second; i < work_.num_nodes; ++i) {
+        event_[i] = (work_.super[i] * (posmut_transition_matrices_[i] *
+                                       work_.lower[i].matrix()).array()).sum();
+        event_[i] = event_[i] / mutation_stats.get_mutation_prob();
+    }
+
+    mutation_stats.set_node_mup(event_, work_.founder_nodes.second);
+
+}
+
+
+void FindMutations::calculate_denovo_mutation(MutationStats &mutation_stats) {
+
+    /**** Forward-Backwards with no-mutation ****/
+    // TODO: Better to use a separate workspace???
+    // TODO: (SW) Agree, maybe separate is better? but might not be necessary, wait and see
+
+    pedigree_.PeelForwards(work_, nomut_transition_matrices_);
+    pedigree_.PeelBackwards(work_, nomut_transition_matrices_);
+    event_.assign(work_.num_nodes, 0.0);
+    double total = 0.0, entropy = 0.0, max_coeff = -1.0;
+    size_t dn_loc = 0, dn_col = 0, dn_row = 0;
+
+    for (std::size_t i = work_.founder_nodes.second; i < work_.num_nodes; ++i) {
+        Eigen::ArrayXXd mat = (work_.super[i].matrix() *
+                               work_.lower[i].matrix().transpose()).array() *
+                              onemut_transition_matrices_[i].array();
+
+        std::size_t row, col;
+        double mat_max = mat.maxCoeff(&row, &col);
+        if (mat_max > max_coeff) {
+            max_coeff = mat_max;
+            dn_row = row;
+            dn_col = col;
+            dn_loc = i;
+        }
+        event_[i] = mat.sum();
+        total += event_[i];
+
+#if CALCULATE_ENTROPY == true
+        entropy += (mat.array() == 0.0).select(mat.array(),
+                                               mat.array() * mat.log()).sum();
+#endif
+
+    }
+    mutation_stats.set_exactly_one_mutation(total);
+
+    if( mutation_stats.get_has_single_mut() ) {
+        mutation_stats.set_node_mu1p(event_, total, work_.founder_nodes.second);
+
+        mutation_stats.dnq = dng::util::lphred<int32_t>(1.0 - (max_coeff / total), 255);
+        mutation_stats.dnl = pedigree_.labels()[dn_loc];
+        if(pedigree_.transitions()[dn_loc].type == Pedigree::TransitionType::Germline) {
+            mutation_stats.dnt = &meiotic_diploid_mutation_labels[dn_row][dn_col][0];
+        } else {
+            mutation_stats.dnt = &mitotic_diploid_mutation_labels[dn_row][dn_col][0];
+        }
+
+#if CALCULATE_ENTROPY == true
+        // Calculate entropy of mutation location
+        entropy = (-entropy / total + log(total)) / M_LN2;
+        entropy /= max_entropies_[ref_index];
+        mutation_stats.dnc = std::round(100.0 * (1.0 - entropy));
+#endif
+
+    }
+
+
+
+}

--- a/src/lib/mutation_stats.cc
+++ b/src/lib/mutation_stats.cc
@@ -1,0 +1,199 @@
+//
+// Created by steven on 2/3/16.
+//
+#include <iostream>
+
+#include <dng/peeling.h>
+
+#include <dng/mutation_stats.h>
+
+
+MutationStats::MutationStats(double min_prob) : min_prob(min_prob) { }
+
+
+bool MutationStats::set_mutation_prob(const double logdata_nomut, const double logdata){
+    // P(mutation | Data ; model) = 1 - [ P(Data, nomut ; model) / P(Data ; model) ]
+    this->logdata_nomut = logdata_nomut;
+    this->logdata = logdata;
+    mup = -std::expm1(logdata_nomut - logdata) ;
+    return mup < min_prob;
+}
+
+
+void MutationStats::set_scaled_log_likelihood(double scale) {
+    lld = (logdata + scale) / M_LN10;
+    llh = logdata / M_LN10;
+
+}
+
+void MutationStats::set_genotype_likelihood(const dng::peel::workspace_t &workspace, const int depth_size) {
+
+    genotype_likelihoods.resize(workspace.num_nodes);
+    for(std::size_t u = 0; u < depth_size; ++u) {
+        std::size_t pos = workspace.library_nodes.first + u;
+        genotype_likelihoods[pos] = workspace.lower[pos].log() / M_LN10;
+        //TODO: Eigen 3.3 might have log10()
+    }
+}
+
+void MutationStats::set_posterior_probabilities(const dng::peel::workspace_t &workspace) {
+
+    posterior_probabilities.resize(workspace.num_nodes);
+    for(std::size_t i = 0; i < workspace.num_nodes; ++i) {
+        posterior_probabilities[i] = WORKSPACE_T_MULTIPLE_UPPER_LOWER(workspace, i);
+        posterior_probabilities[i] /= posterior_probabilities[i].sum();
+    }
+
+}
+
+void MutationStats::set_exactly_one_mutation(double total){
+    mu1p = total * (1.0 - mup);
+    has_single_mut = (mu1p / mup) >= min_prob;
+}
+
+void MutationStats::set_node_mup(const std::vector<double> &event,
+                                 std::size_t first_nonfounder_index) {
+    set_node_core(node_mup, event, first_nonfounder_index);
+}
+
+void MutationStats::set_node_mu1p(std::vector<double> &event, double total,
+                                  std::size_t first_nonfounder_index) {
+    for (std::size_t i = first_nonfounder_index; i < event.size(); ++i) {
+        event[i] = event[i] / total;
+    }
+    set_node_core(node_mu1p, event, first_nonfounder_index);
+}
+
+void MutationStats::set_node_core(std::vector<float> &stats, const std::vector<double> &event,
+                                  std::size_t first_nonfounder_index) {
+    stats.resize(event.size(), hts::bcf::float_missing);
+    for (std::size_t i = first_nonfounder_index; i < event.size(); ++i) {
+        stats[i] = static_cast<float>(event[i]);
+    }
+    //HOWTO: use std::copy with cast??    std::copy(event.begin()+first_nonfounder_index, event.end(), stats.begin() );
+}
+
+
+float MutationStats::get_mutation_prob() const {
+    return mup;
+}
+
+bool MutationStats::get_has_single_mut() const {
+    return has_single_mut;
+}
+
+const dng::GenotypeArray &MutationStats::inspect_posterior_at(int index) const {
+    return posterior_probabilities[index];
+}
+
+const dng::GenotypeArray &MutationStats::inspect_genotype_at(int index) const {
+    return genotype_likelihoods[index];
+}
+
+
+void MutationStats::record_basic_stats(hts::bcf::Variant &record){
+
+    record.info("MUP", mup);
+    record.info("LLD", lld);
+    record.info("LLH", llh);
+    record.info("MUX", mux); //OutputLevel::Complete
+    record.info("MU1P", mu1p); //OutputLevel::single
+
+
+};
+
+void MutationStats::record_single_mutation_stats(hts::bcf::Variant &record){
+
+    if(has_single_mut) {
+        record.info("DNT", dnt);
+        record.info("DNL", dnl);
+        record.info("DNQ", dnq);
+//        record.info("DNC", dnc);
+        record.samples("MU1P", node_mu1p);
+    }
+
+
+};
+
+void MutationStats::record_genotype_stats(hts::bcf::Variant &record){
+    record.sample_genotypes(best_genotypes);
+    record.samples("GQ", genotype_qualities);
+    record.samples("GP", gp_scores);
+    record.samples("GL", gl_scores);
+
+}
+
+void MutationStats::set_genotype_related_stats(const int (&acgt_to_refalt_allele)[5],
+                                               const int (&refalt_to_acgt_allele)[5],
+                                               const uint32_t n_alleles,
+                                               const std::size_t ref_index,
+                                               const std::size_t num_nodes,
+                                               const std::size_t library_start
+) {
+
+// Construct numeric genotypes
+    int numeric_genotype[10][2] = {{0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0},
+                                   {0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}
+    };
+    for(int i = 0; i < 10; ++i) {
+        int n1 = acgt_to_refalt_allele[dng::folded_diploid_nucleotides[i][0]];
+        int n2 = acgt_to_refalt_allele[dng::folded_diploid_nucleotides[i][1]];
+        if(n1 > n2) {
+            numeric_genotype[i][0] = hts::bcf::encode_allele_unphased(n2);
+            numeric_genotype[i][1] = hts::bcf::encode_allele_unphased(n1);
+        } else {
+            numeric_genotype[i][0] = hts::bcf::encode_allele_unphased(n1);
+            numeric_genotype[i][1] = hts::bcf::encode_allele_unphased(n2);
+        }
+    }
+    // Link VCF genotypes to our order
+    int genotype_index[15];
+    for(int i = 0, k = 0; i < n_alleles; ++i) {
+        int n1 = refalt_to_acgt_allele[i];
+        for(int j = 0; j <= i; ++j, ++k) {
+            int n2 = refalt_to_acgt_allele[j];
+            genotype_index[k] = (j == 0 && ref_index == 4) ?
+                                -1 : dng::folded_diploid_genotypes_matrix[n1][n2];
+        }
+    }
+
+    // Calculate sample genotypes
+//    std::vector<int32_t> best_genotypes(2 * num_nodes);
+//    std::vector<int32_t> genotype_qualities(num_nodes);
+    int gt_count = n_alleles * (n_alleles + 1) / 2;
+//    std::vector<float> gp_scores(gt_count*num_nodes );
+    best_genotypes.resize(2 * num_nodes);
+    genotype_qualities.resize(num_nodes);
+    gp_scores.resize( gt_count * num_nodes);
+
+    for(size_t i = 0, k = 0; i < num_nodes; ++i) {
+        size_t pos;
+        double d = posterior_probabilities[i].maxCoeff(&pos);
+        best_genotypes[2 * i] = numeric_genotype[pos][0];
+        best_genotypes[2 * i + 1] = numeric_genotype[pos][1];
+        genotype_qualities[i] = dng::util::lphred<int32_t>(1.0 - d, 255);
+        // If either of the alleles is missing set quality to 0
+        if(hts::bcf::allele_is_missing({best_genotypes[2 * i]}) ||
+                hts::bcf::allele_is_missing({best_genotypes[2 * i + 1]})) {
+            genotype_qualities[i] = 0;
+        }
+        for(int j = 0; j < gt_count; ++j) {
+            int n = genotype_index[j];
+            gp_scores[k++] = (n == -1) ? 0.0 : posterior_probabilities[i][n];
+        }
+    }
+
+    // Sample Likelihoods
+//    std::vector<float> gl_scores.(gt_count *num_nodes, hts::bcf::float_missing);
+    gl_scores.resize(gt_count *num_nodes, hts::bcf::float_missing);
+    for(size_t i = library_start, k = library_start * gt_count; i < num_nodes;
+        ++i) {
+        for(int j = 0; j < gt_count; ++j) {
+            int n = genotype_index[j];
+            gl_scores[k++] = (n == -1) ? hts::bcf::float_missing :
+                             genotype_likelihoods[i][n];
+        }
+    }
+
+
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -52,22 +52,27 @@ SET_TESTS_PROPERTIES(build_gitkeep PROPERTIES
 
 ################################################################################
 # Compile unit tests
-include_directories(../src/include)
+include_directories(${CMAKE_SOURCE_DIR}/src/include)
+include_directories(${CMAKE_SOURCE_DIR}/src)
+include_directories(./src/)
+
+SET(UNITTEST_LIBRARIES Threads::Threads
+        Boost::PROGRAM_OPTIONS
+        Boost::FILESYSTEM
+        Boost::SYSTEM
+        Boost::UNIT_TEST_FRAMEWORK
+        EIGEN3::EIGEN3
+        HTSLIB::HTSLIB
+        )
+
 
 # Make a test for each unit test file located in test/ dir
 file(GLOB_RECURSE TESTS test_*[cc|cpp])
 foreach(test ${TESTS})
   get_filename_component(testName ${test} NAME_WE)
   add_executable(${testName} EXCLUDE_FROM_ALL ${test})
-  target_link_libraries(${testName}
-    Threads::Threads
-    Boost::PROGRAM_OPTIONS
-    Boost::FILESYSTEM
-    Boost::SYSTEM
-    Boost::UNIT_TEST_FRAMEWORK
-    EIGEN3::EIGEN3
-    HTSLIB::HTSLIB
-  )
+  target_link_libraries(${testName} ${UNITTEST_LIBRARIES})
+
   add_test(${testName}_build "${CMAKE_COMMAND}" --build ${CMAKE_BINARY_DIR} --target ${testName})
   add_test(${testName}_run ${testName})
   set_tests_properties(${testName}_run PROPERTIES DEPENDS ${testName}_build)
@@ -76,34 +81,62 @@ endforeach(test)
 ################################################################################
 
 
-
 ################################################################################
-# temp Compile unit tests with *.cc
-# TODO: Use a different filename pattern for now (test2_* instead of test_*).
-# TODO: How to add min *.cc files instead of all *.cc later?
-include_directories(./)
+## TODO: How to build something like "make timetrail" and compile all time measuring files
+IF(DEVEL_MODE)
+  ADD_DEFINITIONS(-DDNG_DEVEL)
+ENDIF()
 
-file(GLOB_RECURSE TESTS2 "test2_*[cc|cpp]")
+file(GLOB_RECURSE TESTS2 "testt_time*[cc|cpp]")
 foreach(test ${TESTS2})
   get_filename_component(testName ${test} NAME_WE)
   add_executable(${testName} EXCLUDE_FROM_ALL ${test}
           ${CMAKE_SOURCE_DIR}/src/lib/peeling.cc
-          ##            ../src/lib/likelihood.cc ../src/lib/newick.cc ../src/lib/pedigree.cc
-          ##            ../src/lib/mutation.cc ../src/lib/stats.cc
+          ${CMAKE_SOURCE_DIR}/src/lib/likelihood.cc
+          ${CMAKE_SOURCE_DIR}/src/lib/newick.cc
+          ${CMAKE_SOURCE_DIR}/src/lib/pedigree.cc
+          ${CMAKE_SOURCE_DIR}/src/lib/mutation.cc
+          ${CMAKE_SOURCE_DIR}/src/lib/stats.cc
           )
-  target_link_libraries(${testName}
-          Threads::Threads
-          Boost::PROGRAM_OPTIONS
-          Boost::FILESYSTEM
-          Boost::SYSTEM
-          Boost::UNIT_TEST_FRAMEWORK
-          EIGEN3::EIGEN3
-          HTSLIB::HTSLIB
+
+  target_link_libraries(${testName} ${UNITTEST_LIBRARIES})
+
+  IF(DEVEL_MODE)
+    TARGET_LINK_LIBRARIES(${testName} Boost::TIMER)
+  ENDIF()
+#  add_test(${testName}_build "${CMAKE_COMMAND}" --build ${CMAKE_BINARY_DIR} --target ${testName})
+#  add_test(${testName}_run ${testName})
+#  set_tests_properties(${testName}_run PROPERTIES DEPENDS ${testName}_build)
+endforeach(test)
+
+
+
+# Temp Compile unit tests with *.cc
+# TODO: Use a different filename pattern for now (test2_* instead of test_*).
+# TODO: How to add min *.cc files instead of all *.cc later?
+
+add_definitions(-DTESTDATA_DIR=\"${TESTDATA_DIR}\")
+file(GLOB_RECURSE TESTS2 "test2_*[cc|cpp]")
+foreach (test ${TESTS2})
+  get_filename_component(testName ${test} NAME_WE)
+  add_executable(${testName} EXCLUDE_FROM_ALL ${test}
+          ${CMAKE_SOURCE_DIR}/src/lib/peeling.cc
+          ${CMAKE_SOURCE_DIR}/src/lib/likelihood.cc
+          ${CMAKE_SOURCE_DIR}/src/lib/newick.cc
+          ${CMAKE_SOURCE_DIR}/src/lib/pedigree.cc
+          ${CMAKE_SOURCE_DIR}/src/lib/mutation.cc
+          ${CMAKE_SOURCE_DIR}/src/lib/stats.cc
+
+#          ${CMAKE_SOURCE_DIR}/src/lib/pedigree_v2.cc
+          ${CMAKE_SOURCE_DIR}/src/lib/find_mutation.cc
+          ${CMAKE_SOURCE_DIR}/src/lib/mutation_stats.cc
           )
+  target_link_libraries(${testName} ${UNITTEST_LIBRARIES})
+
   add_test(${testName}_build "${CMAKE_COMMAND}" --build ${CMAKE_BINARY_DIR} --target ${testName})
   add_test(${testName}_run ${testName})
   set_tests_properties(${testName}_run PROPERTIES DEPENDS ${testName}_build)
-endforeach(test)
+endforeach (test)
 
 ################################################################################
 

--- a/test/src/boost_test_helper.h
+++ b/test/src/boost_test_helper.h
@@ -1,0 +1,96 @@
+//
+// Created by steven on 1/15/16.
+//
+// Replace some with with BOOST later
+//
+
+#ifndef DENOVOGEAR_BOOST_TEST_HELPER_H
+#define DENOVOGEAR_BOOST_TEST_HELPER_H
+
+#include <boost/test/test_tools.hpp>
+#include <boost/test/unit_test.hpp>
+
+//TODO: Where should this file go?
+//FIXME: too many global
+const double ABS_TEST_THRESHOLD = 1e-10;
+const double BOOST_CLOSE_THRESHOLD = 1e-3;//
+const double BOOST_SMALL_THRESHOLD = sqrt(std::numeric_limits<double>::epsilon());
+//TODO: What is a good cut? 1e-8?// sqrt(std::numeric_limits<double>::epsilon());
+
+
+template<typename V, typename V2>
+void boost_check_equal_vector(V &expected, V2 &result) {
+
+    BOOST_CHECK_EQUAL(expected.size(), result.size());
+    for (int i = 0; i < expected.size(); ++i) {
+        BOOST_CHECK(expected[i] == result[i]);
+    }
+}
+
+template<typename V, typename V2>
+void boost_check_close_vector(V &expected, V2 &result) {
+
+    BOOST_CHECK_EQUAL(expected.size(), result.size());
+    for (int i = 0; i < expected.size(); ++i) {
+        if(expected[i] == 0){
+            BOOST_CHECK_EQUAL(0, result[i]);
+        }
+        else {
+            BOOST_CHECK_CLOSE(expected[i], result[i], BOOST_CLOSE_THRESHOLD);
+        }
+    }
+}
+
+template<typename V, typename V2>
+void boost_check_close_vector(V &&expected, V2 &result) {
+
+    BOOST_CHECK_EQUAL(expected.size(), result.size());
+    for (int i = 0; i < expected.size(); ++i) {
+        if(expected[i] == 0){
+            BOOST_CHECK_EQUAL(0, result[i]);
+        }
+        else {
+            BOOST_CHECK_CLOSE(expected[i], result[i], BOOST_CLOSE_THRESHOLD);
+        }
+    }
+}
+
+template<typename V, typename V2>
+void boost_check_close_vector(V &expected, V2 &result, int expected_size) {
+    
+    BOOST_CHECK_EQUAL(expected_size, expected.size());
+    boost_check_close_vector(expected, result);
+}
+
+
+
+template<typename M>
+void boost_check_matrix(M &expected, M &result) {
+    BOOST_CHECK_EQUAL(expected.rows(), result.rows());
+    BOOST_CHECK_EQUAL(expected.cols(), result.cols());
+
+    for (int i = 0; i < expected.rows(); ++i) {
+        for (int j = 0; j < expected.cols(); ++j) {
+            if(expected(i,j) == 0 ){
+                BOOST_CHECK_EQUAL(0, result(i,j));
+            }
+            else {
+                BOOST_CHECK_CLOSE(expected(i, j), result(i, j), BOOST_CLOSE_THRESHOLD);
+            }
+        }
+    }
+}
+
+
+template<typename M>
+void boost_check_matrix(M &expected, M &result, int expected_rows, int expected_cols) {
+    BOOST_CHECK_EQUAL(expected_rows, expected.rows());
+    BOOST_CHECK_EQUAL(expected_cols, expected.cols());
+
+    boost_check_matrix(expected, result);
+}
+
+
+
+
+#endif //DENOVOGEAR_BOOST_TEST_HELPER_H

--- a/test/src/fixture/fixture_random_family.h
+++ b/test/src/fixture/fixture_random_family.h
@@ -1,0 +1,147 @@
+//
+// Created by steven on 1/24/16.
+//
+#pragma once
+#ifndef DENOVOGEAR_FIXTURE_RANDOM_FAMILY_H
+#define DENOVOGEAR_FIXTURE_RANDOM_FAMILY_H
+
+#include <dng/peeling.h>
+
+namespace utf = boost::unit_test;
+
+
+struct RandomFamily {
+    const int CHILD_OFFSET = 2;
+    std::string fixture;
+
+    std::mt19937 random_gen_mt {1}; //seed = 1
+
+
+    dng::peel::family_members_t family;
+    std::vector<dng::TransitionMatrix> trans_matrix;
+    std::vector<dng::GenotypeArray> upper_array;
+    std::vector<dng::GenotypeArray> lower_array;
+
+    int num_child;
+    int total_family_size;
+    std::uniform_int_distribution<> rand_unif;
+
+    RandomFamily(std::string s = "RandomFamily") : fixture(s) {
+        BOOST_TEST_MESSAGE("set up fixture:  " << fixture);
+        rand_unif = std::uniform_int_distribution<>(1,10);
+        init_family();
+    }
+
+    void init_family(){
+
+        int num_child = rand_unif(random_gen_mt);
+        total_family_size = num_child + CHILD_OFFSET;
+        family.clear();
+        trans_matrix.resize(total_family_size);
+        upper_array.resize(total_family_size);
+        lower_array.resize(total_family_size);
+
+        for (int k = 0; k < total_family_size; ++k) {
+            family.push_back(k);
+            lower_array[k] = dng::GenotypeArray::Random();
+            if (k < CHILD_OFFSET) {
+                trans_matrix[k] = dng::TransitionMatrix::Random(10, 10);
+                upper_array[k] = dng::GenotypeArray::Random();
+            }
+            else {
+                trans_matrix[k] = dng::TransitionMatrix::Random(100, 10);
+            }
+
+        }
+    }
+
+    void init_family_parent_child_only(){
+
+        total_family_size = 2;
+
+        family.clear();
+        trans_matrix.resize(total_family_size);
+        upper_array.resize(total_family_size);
+        lower_array.resize(total_family_size);
+
+        for (int k = 0; k < total_family_size; ++k) {
+            family.push_back(k);
+            trans_matrix[k] = dng::TransitionMatrix::Random(10, 10);
+            lower_array[k] = dng::GenotypeArray::Random();
+//            upper_array[k] = GenotypeArray::Random();
+
+        }
+    }
+
+    ~RandomFamily() {
+        BOOST_TEST_MESSAGE("tear down fixture: " << fixture);
+    }
+};
+
+void copy_family_to_workspace(dng::peel::workspace_t &workspace, dng::TransitionVector &full_matrix,
+                              int total_family_size, const std::vector<dng::GenotypeArray> &lower,
+                              const std::vector<dng::GenotypeArray> &upper,
+                              const std::vector<dng::TransitionMatrix> &trans_mat) {
+    workspace.Resize(total_family_size);
+    full_matrix.resize(total_family_size);
+    for (int l = 0; l < total_family_size; ++l) {
+        workspace.lower[l] = lower[l];
+        workspace.upper[l] = upper[l];
+        full_matrix[l] = trans_mat[l];
+    }
+}
+
+
+struct RandomWorkspace {
+
+
+    std::string fixture;
+
+    dng::peel::workspace_t workspace;
+    dng::TransitionVector full_matrix;
+
+    RandomWorkspace(std::string s = "") : fixture(s) {
+        BOOST_TEST_MESSAGE("set up fixture: RandomWorkspace " << s);
+
+    }
+
+    void init_workspace(){
+        RandomFamily family;
+
+        family.init_family();
+        copy_family_to_workspace(workspace, full_matrix,
+                                 family.total_family_size, family.lower_array, family.upper_array,
+                                 family.trans_matrix);
+
+    }
+
+
+    ~RandomWorkspace() {
+        BOOST_TEST_MESSAGE("tear down fixture: RandomWorkspace " << fixture);
+    }
+//        int num_child = rand_unif(random_gen_mt);
+//        total_family_size = num_child + CHILD_OFFSET;
+//
+//        family.clear();
+//        trans_matrix.resize(total_family_size);
+//        upper_array.resize(total_family_size);
+//        lower_array.resize(total_family_size);
+//
+//        for (int k = 0; k < total_family_size; ++k) {
+//            family.push_back(k);
+//            lower_array[k] = dng::GenotypeArray::Random();
+//            if (k < CHILD_OFFSET) {
+//                trans_matrix[k] = dng::TransitionMatrix::Random(10, 10);
+//                upper_array[k] = dng::GenotypeArray::Random();
+//            }
+//            else {
+//                trans_matrix[k] = dng::TransitionMatrix::Random(100, 10);
+//
+//            }
+//
+//    void init_family(){
+};
+
+
+
+#endif //DENOVOGEAR_FIXTURE_RANDOM_FAMILY_H

--- a/test/src/fixture/fixture_read_trio_from_file.h
+++ b/test/src/fixture/fixture_read_trio_from_file.h
@@ -1,0 +1,98 @@
+//
+// Created by steven on 2/12/16.
+//
+
+#pragma once
+#ifndef DENOVOGEAR_FIXTURE_READ_TRIO_FROM_FILE_H
+#define DENOVOGEAR_FIXTURE_READ_TRIO_FROM_FILE_H
+
+#include <fstream>
+
+#include <dng/task/call.h>
+#include <utils/boost_utils.h>
+#include <helpers/find_mutation_helper.h>
+
+
+using namespace dng;
+namespace utf = boost::unit_test;
+
+struct ReadTrioFromFile {
+
+    std::string fixture;
+
+    dng::io::Pedigree ped;
+    dng::ReadGroups rgs;
+
+    typedef dng::task::Call task_type;
+    struct arg_t : public task_type::argument_type {
+        bool help;
+        bool version;
+        std::string arg_file;
+
+        std::string run_name;
+        std::string run_path;
+    } arg;
+
+    ReadTrioFromFile(std::string s = "ReadTrioFromFile") : fixture(s) {
+        BOOST_TEST_MESSAGE("set up fixture: " << fixture);
+
+        po::options_description ext_desc_, int_desc_;
+        po::positional_options_description pos_desc_;
+        po::variables_map vm_;
+
+        int argc=4;
+        char *argv[argc];
+        argv[0] = (char*) "test";
+        argv[1] = (char*) "-p";
+
+        std::string ped_filename (TESTDATA_DIR);
+        ped_filename.append("/sample_5_3/ceu.ped");
+        argv[2] = (char*) ped_filename.data();
+
+        std::string vcf_filename = TESTDATA_DIR;
+        vcf_filename.append("/sample_5_3/test1.vcf");
+        argv[3] = (char*) vcf_filename.data();
+
+        add_app_args(ext_desc_, static_cast<typename task_type::argument_type &>(arg));
+        int_desc_.add_options()
+                ("input", po::value< std::vector<std::string> >(&arg.input), "input files")
+                ;
+        int_desc_.add(ext_desc_);
+        pos_desc_.add("input", -1);
+        po::store(po::command_line_parser(argc, argv)
+                          .options(int_desc_).positional(pos_desc_).run(), vm_);
+        po::notify(vm_);
+
+        // Parse pedigree from file
+
+        std::ifstream ped_file(arg.ped);
+        ped.Parse(utils::istreambuf_range(ped_file));
+
+
+        std::vector<hts::File> indata;
+        std::vector<hts::bcf::File> bcfdata;
+        for (auto &&str : arg.input) {
+            indata.emplace_back(str.c_str(), "r");
+            if (indata.back().is_open()) {
+                continue;
+            }
+            throw std::runtime_error("unable to open input file '" + str + "'.");
+        }
+        bcfdata.emplace_back(std::move(indata[0]));
+        rgs.ParseSamples(bcfdata[0]);
+
+
+
+    }
+
+
+
+    ~ReadTrioFromFile() {
+        BOOST_TEST_MESSAGE("tear down fixture: " << fixture);
+    }
+
+
+};
+
+
+#endif //DENOVOGEAR_FIXTURE_READ_TRIO_FROM_FILE_H

--- a/test/src/fixture/fixture_trio_workspace.h
+++ b/test/src/fixture/fixture_trio_workspace.h
@@ -1,0 +1,89 @@
+//
+// Created by steven on 2/23/16.
+//
+
+#pragma once
+#ifndef DENOVOGEAR_FIXTURE_TRIO_WORKSPACE_H
+#define DENOVOGEAR_FIXTURE_TRIO_WORKSPACE_H
+
+#include <helpers/find_mutation_helper.h>
+#include <fixture/fixture_read_trio_from_file.h>
+
+struct TrioWorkspace : public  ReadTrioFromFile {
+
+    double min_prob;
+
+    dng::Pedigree pedigree;
+    dng::peel::workspace_t workspace;
+
+    int ref_index = 2;
+    std::vector<depth_t> read_depths{3};
+
+    FindMutations::params_t test_param_1 {0, {0,0,0,0}, 0,
+                                          std::string("0,0,0,0"),
+                                          std::string("0,0,0,0") };
+
+    TrioWorkspace(std::string s = "TrioWorkspace") : ReadTrioFromFile(s) {
+        BOOST_TEST_MESSAGE("set up fixture: " << fixture);
+
+
+        pedigree.Construct(ped, rgs, arg.mu, arg.mu_somatic, arg.mu_library);
+
+        std::array<double, 4> freqs;
+        auto f = util::parse_double_list(arg.nuc_freqs, ',', 4);
+        std::copy(f.first.begin(), f.first.end(), &freqs[0]);
+
+        test_param_1 = FindMutations::params_t {arg.theta, freqs, arg.ref_weight, arg.gamma[0], arg.gamma[1]};
+
+
+        int min_qual = arg.min_basequal;
+        min_prob = arg.min_prob;
+
+        ref_index = 2;
+        uint16_t cc[3][4] = {{0, 1, 25, 29},
+                             {0, 0, 57, 0},
+                             {0, 0, 76, 1}};
+        for (int j = 0; j < 3; ++j) {
+            std::copy(cc[j], cc[j] + 4, read_depths[j].counts);
+        }
+        setup_workspace(ref_index, read_depths);
+
+    }
+
+    double setup_workspace(int ref_index, std::vector<depth_t> &read_depths ){
+
+        workspace.Resize(5);
+        workspace.founder_nodes = std::make_pair(0, 2);
+        workspace.germline_nodes = std::make_pair(0, 2);
+        workspace.somatic_nodes = std::make_pair(2, 2);
+        workspace.library_nodes = std::make_pair(2, 5);
+
+        std::array<double, 4> prior {};
+        prior.fill(0);
+        prior[ref_index] = test_param_1.ref_weight;
+        auto genotype_prior_prior = population_prior(test_param_1.theta, test_param_1.nuc_freq, prior);
+        workspace.SetFounders(genotype_prior_prior);
+
+        std::vector<std::string> expect_gamma{"0.98, 0.0005, 0.0005, 1.04",
+                                              "0.02, 0.075,  0.005,  1.18"};
+        dng::genotype::DirichletMultinomialMixture genotype_likelihood_{
+                dng::genotype::DirichletMultinomialMixture::params_t {expect_gamma[0]},
+                dng::genotype::DirichletMultinomialMixture::params_t {expect_gamma[1]}  };
+        double scale = 0.0, stemp;
+        for (std::size_t u = 0; u < read_depths.size(); ++u) {
+            std::tie(workspace.lower[2 + u], stemp) =
+                    genotype_likelihood_(read_depths[u], ref_index);
+            scale += stemp;
+        }
+        return scale;
+    }
+
+    ~TrioWorkspace() {
+        BOOST_TEST_MESSAGE("tear down fixture: " << fixture);
+    }
+
+
+};
+
+
+#endif //DENOVOGEAR_FIXTURE_TRIO_WORKSPACE_H

--- a/test/src/lib/test2_find_mutation.cc
+++ b/test/src/lib/test2_find_mutation.cc
@@ -1,0 +1,322 @@
+//
+// Created by steven on 2/4/16.
+//
+
+
+#define BOOST_TEST_MODULE dng::lib::find_mutation
+
+#include <boost/test/unit_test.hpp>
+
+#include <ctime>
+#include <iostream>
+#include <fstream>
+
+#include <dng/task/call.h>
+#include <helpers/find_mutation_helper.h>
+
+#include <boost_test_helper.h>
+#include <fixture/fixture_trio_workspace.h>
+
+
+
+namespace utf = boost::unit_test;
+
+const int NUM_TEST = 100;
+
+//TODO: Remove this at some stage. This was defined in peeling.cc
+#define WORKSPACE_T_MULTIPLE_UPPER_LOWER(workspace, index) \
+    (workspace.upper[index] * workspace.lower[index])
+
+
+// TODO: Example of BOOST_DATA_TEST_CASE and BOOST_PARAM_TEST_CASE.
+// TODO: Should be able to replace the for loop with these.
+// TODO: Might not be able to use fixture.
+//
+//
+//std::vector<int> test_types;//
+//
+//BOOST_AUTO_TEST_SUITE(suite1,
+//  * utf::fixture<Fx>(std::string("FX"))
+//  * utf::fixture<Fx>(std::string("FX2")))
+//
+//  BOOST_AUTO_TEST_CASE(test1, * utf::fixture(&setup, &teardown))
+//  {
+//    BOOST_TEST_MESSAGE("running test1");
+//    BOOST_TEST(true);
+//  }
+//
+//  BOOST_AUTO_TEST_CASE(test2)
+//  {
+//    BOOST_TEST_MESSAGE("running test2");
+//    BOOST_TEST(true);
+//  }
+//
+//BOOST_DATA_TEST_CASE( test_case_arity1, data::xrange(5), my_var )
+//{
+//    BOOST_TEST_MESSAGE("running data: ");
+//    BOOST_TEST((my_var <= 4 && my_var >= 0));
+//}
+//BOOST_PARAM_TEST_CASE(test_function, params_begin, params_end);
+//BOOST_AUTO_TEST_SUITE_END()
+
+
+//BOOST_AUTO_TEST_SUITE(test_peeling_suite,  * utf::fixture<Fx>(std::string("FX")) )
+
+
+
+void setup() { BOOST_TEST_MESSAGE("set up fun"); }
+
+void teardown() { BOOST_TEST_MESSAGE("tear down fun"); }
+
+
+
+BOOST_FIXTURE_TEST_SUITE(test_find_mutation_suite, TrioWorkspace )
+
+BOOST_AUTO_TEST_CASE(test_constructor, *utf::fixture(&setup, &teardown)) {
+
+    FindMutationsGetter find_mutation {min_prob, pedigree, test_param_1};
+
+    BOOST_CHECK_EQUAL(find_mutation.getMin_prob_() , 0.01);
+
+    //getParams_()
+    BOOST_CHECK_EQUAL(find_mutation.getParams_().theta, 0.001);//test_param_1.theta);
+    BOOST_CHECK_EQUAL(find_mutation.getParams_().ref_weight, 1);//test_param_1.ref_weight);
+
+    std::array<double, 4> expect_freqs{0.3, 0.2, 0.2, 0.3};
+    auto freqs1 = find_mutation.getParams_().nuc_freq;
+    boost_check_close_vector(expect_freqs, freqs1, 4);
+//    for (int j = 0; j < 4; ++j) {
+//        BOOST_CHECK_EQUAL(freqs1[j], expect_freqs[j]);
+//    }
+    std::vector<std::array<double, 4>> expect_gamma{{0.98, 0.0005, 0.0005, 1.04},
+                                                    {0.02, 0.075,  0.005,  1.18}};
+    auto gamma_a = find_mutation.getParams_().params_a;
+    BOOST_CHECK_EQUAL(gamma_a.pi, expect_gamma[0][0]);
+    BOOST_CHECK_EQUAL(gamma_a.phi, expect_gamma[0][1]);
+    BOOST_CHECK_EQUAL(gamma_a.epsilon, expect_gamma[0][2]);
+    BOOST_CHECK_EQUAL(gamma_a.omega, expect_gamma[0][3]);
+
+    auto gamma_b = find_mutation.getParams_().params_b;
+    BOOST_CHECK_EQUAL(gamma_b.pi, expect_gamma[1][0]);
+    BOOST_CHECK_EQUAL(gamma_b.phi, expect_gamma[1][1]);
+    BOOST_CHECK_EQUAL(gamma_b.epsilon, expect_gamma[1][2]);
+    BOOST_CHECK_EQUAL(gamma_b.omega, expect_gamma[1][3]);
+
+#if CALCULATE_ENTROPY == true
+    auto event = find_mutation.getEvent_();
+    BOOST_CHECK_EQUAL(event.size(), 5);
+    for (int k = 0; k < 5; ++k) {
+        BOOST_CHECK_EQUAL(event[k], 0);
+    }
+#endif
+}
+
+
+
+BOOST_AUTO_TEST_CASE(test_prior, *utf::fixture(&setup, &teardown)) {
+
+    std::vector<std::array<double, 10>> expected_prior {
+        {0.998951118846171, 0.000199760259730275, 0.000199760259730275, 0.000299640389595412, 9.98701448476561e-05, 3.99400699250774e-08, 5.99101048876161e-08, 9.98701448476561e-05, 5.99101048876161e-08, 0.000149820194797706},
+        {0.000149820194797706, 0.000299610434542968, 5.99101048876161e-08, 8.98651573314242e-08, 0.998801318621409, 0.000199740289695312, 0.000299610434542968, 9.98701448476561e-05, 5.99101048876161e-08, 0.000149820194797706},
+        {0.000149820194797706, 5.99101048876161e-08, 0.000299610434542968, 8.98651573314242e-08, 9.98701448476561e-05, 0.000199740289695312, 5.99101048876161e-08, 0.998801318621409, 0.000299610434542968, 0.000149820194797706},
+        {0.000149820194797706, 5.99101048876161e-08, 5.99101048876161e-08, 0.000299640389595412, 9.98701448476561e-05, 3.99400699250774e-08, 0.000199760259730275, 9.98701448476561e-05, 0.000199760259730275, 0.998951118846171},
+        {0.29979020979021, 0.00011988011988012, 0.00011988011988012, 0.00017982017982018, 0.19984015984016, 7.99200799200799e-05, 0.00011988011988012, 0.19984015984016, 0.00011988011988012, 0.29979020979021 }
+    };
+
+    FindMutationsGetter find_mutation {min_prob, pedigree, test_param_1};
+    auto *pArray = find_mutation.getGenotype_prior_();
+
+    for (int i = 0; i < 5; ++i) {
+        auto prior_array = pArray[i];
+        boost_check_close_vector(expected_prior[i], prior_array);
+    }
+
+
+}
+
+BOOST_AUTO_TEST_CASE(test_full_transition, *utf::fixture(&setup, &teardown)) {
+
+    std::array<double, 4> freqs{0.3, 0.2, 0.2, 0.3};
+    double mu = 1e-8;
+    auto dad = f81::matrix(3*mu, freqs);
+    auto mom = f81::matrix(3*mu, freqs);
+
+    auto exp_germline_full = meiosis_diploid_matrix(dad, mom);
+    auto exp_germline_nomut = meiosis_diploid_matrix(dad, mom, 0);
+    auto exp_germline_posmut = exp_germline_full - exp_germline_nomut;
+    auto exp_germline_onemut = meiosis_diploid_matrix(dad, mom, 1);
+    auto exp_germline_mean = meiosis_diploid_mean_matrix(dad, mom);
+
+
+    auto orig = f81::matrix(2*mu, freqs);
+    auto exp_somatic_full = mitosis_diploid_matrix(orig);
+    auto exp_somatic_nomut = mitosis_diploid_matrix(orig, 0);
+    auto exp_somatic_posmut = exp_somatic_full - exp_somatic_nomut;
+    auto exp_somatic_onemut = mitosis_diploid_matrix(orig, 1);
+    auto exp_somatic_mean = mitosis_diploid_mean_matrix(orig);
+
+
+    FindMutationsGetter find_mutation {min_prob, pedigree, test_param_1};
+    auto full_matrices = find_mutation.getFull_transition_matrices_();
+    auto nomut_matrices = find_mutation.getNomut_transition_matrices_();
+    auto posmut_matrices = find_mutation.getPosmut_transition_matrices_();
+    auto onemut_matrices = find_mutation.getOnemut_transition_matrices_();
+    auto mean_matrices = find_mutation.getMean_matrices_();
+
+    std::vector<TransitionMatrix> exp_full {{},{},exp_germline_full, exp_somatic_full, exp_somatic_full};
+    std::vector<TransitionMatrix> exp_nomut {{},{},exp_germline_nomut, exp_somatic_nomut, exp_somatic_nomut};
+    std::vector<TransitionMatrix> exp_posmut {{},{},exp_germline_posmut, exp_somatic_posmut, exp_somatic_posmut};
+    std::vector<TransitionMatrix> exp_onemut {{},{},exp_germline_onemut, exp_somatic_onemut, exp_somatic_onemut};
+    std::vector<TransitionMatrix> exp_mean {{},{},exp_germline_mean, exp_somatic_mean, exp_somatic_mean};
+    for (int i = 0; i < 5; ++i) {
+        boost_check_matrix(exp_full[i],   full_matrices[i]);
+        boost_check_matrix(exp_nomut[i],  nomut_matrices[i]);
+        boost_check_matrix(exp_posmut[i], posmut_matrices[i]);
+        boost_check_matrix(exp_onemut[i], onemut_matrices[i]);
+        boost_check_matrix(exp_mean[i],   mean_matrices[i]);
+    }
+}
+
+
+BOOST_AUTO_TEST_CASE(test_operator, *utf::fixture(&setup, &teardown)) {
+
+
+
+    std::vector<peel::family_members_t> family {
+            {1,4},
+            {0,1,2},
+            {0,3}
+    };
+    min_prob = 0;
+    FindMutations::stats_t stats;
+    FindMutationsGetter find_mutation{min_prob, pedigree, test_param_1};
+    find_mutation(read_depths, ref_index, &stats);
+
+
+    double scale = setup_workspace(ref_index, read_depths);
+
+    //Test basic stats
+    auto nomut_matrices = find_mutation.getNomut_transition_matrices_();
+    workspace.CleanupFast();
+    dng::peel::up(workspace, family[0], nomut_matrices);
+    dng::peel::to_father_fast(workspace, family[1], nomut_matrices);
+    dng::peel::up(workspace, family[2], nomut_matrices);
+    double result_nomut = log((workspace.lower[0] * workspace.upper[0]).sum());
+
+
+    auto full_matrices = find_mutation.getFull_transition_matrices_();
+    workspace.CleanupFast();
+    dng::peel::up(workspace, family[0], full_matrices );
+    dng::peel::to_father(workspace, family[1], full_matrices );
+    dng::peel::up(workspace, family[2], full_matrices );
+    double result_full = log((workspace.lower[0] * workspace.upper[0]).sum());
+//    std::cout << "Expected: " << result_nomut << std::endl;
+//    std::cout << "Expected full: " << result_full << std::endl;
+
+
+    // P(mutation | Data ; model) = 1 - [ P(Data, nomut ; model) / P(Data ; model) ]
+    const double expected_mup = -std::expm1(result_nomut - result_full);
+    const double expected_lld = (result_full +scale) / M_LN10;
+    const double expected_llh = result_full / M_LN10;
+
+    BOOST_CHECK_CLOSE(expected_mup, stats.mup, BOOST_CLOSE_THRESHOLD);
+    BOOST_CHECK_CLOSE(expected_lld, stats.lld, BOOST_CLOSE_THRESHOLD);
+    BOOST_CHECK_CLOSE(expected_llh, stats.llh, BOOST_CLOSE_THRESHOLD);
+
+
+    std::cout << stats.mup << "\t" << stats.llh << std::endl;
+    std::cout << "EXP: " << expected_mup << "\t" << expected_llh << std::endl;
+
+    //Test posterior
+    full_matrices = find_mutation.getFull_transition_matrices_();
+    workspace.CleanupFast();
+    dng::peel::up(workspace, family[0], full_matrices );
+    dng::peel::to_father(workspace, family[1], full_matrices );
+    dng::peel::up(workspace, family[2], full_matrices );
+
+    dng::peel::up_reverse(workspace, family[2], full_matrices );
+    dng::peel::to_father_reverse(workspace, family[1], full_matrices );
+    dng::peel::up_reverse(workspace, family[0], full_matrices );
+
+    dng::GenotypeArray expected_posterior;
+    for(std::size_t i = 0; i < workspace.num_nodes; ++i) {
+        expected_posterior = WORKSPACE_T_MULTIPLE_UPPER_LOWER(workspace, i);
+        expected_posterior /= expected_posterior.sum();
+
+        boost_check_close_vector(expected_posterior, stats.posterior_probabilities[i]);
+    }
+
+
+
+}
+
+
+BOOST_AUTO_TEST_CASE(test_calculate_mutation_expected, *utf::fixture(&setup, &teardown)) {
+
+    FindMutationsGetter find_mutation{min_prob, pedigree, test_param_1};
+
+    MutationStats mutation_stats(min_prob);
+    find_mutation.calculate_mutation(read_depths, ref_index, mutation_stats);
+
+    BOOST_CHECK_CLOSE(0.116189, mutation_stats.mup, BOOST_CLOSE_THRESHOLD);
+    BOOST_CHECK_CLOSE(-30.5967, mutation_stats.lld, BOOST_CLOSE_THRESHOLD);
+    BOOST_CHECK_CLOSE(-6.68014, mutation_stats.llh, BOOST_CLOSE_THRESHOLD);
+    BOOST_CHECK_CLOSE(0.116189, mutation_stats.mux, BOOST_CLOSE_THRESHOLD);
+    BOOST_CHECK_CLOSE(0.116189, mutation_stats.mu1p, BOOST_CLOSE_THRESHOLD);
+
+    BOOST_CHECK_EQUAL("GGxGG>GT", mutation_stats.dnt);
+    BOOST_CHECK_EQUAL("LB-NA12878:Solexa-135852", mutation_stats.dnl);
+    BOOST_CHECK_EQUAL(42, mutation_stats.dnq);
+
+
+}
+
+
+BOOST_AUTO_TEST_CASE(test_calculate_mutation, *utf::fixture(&setup, &teardown)) {
+    //TODO: Compare operator() with calculate_mutation ONLY, NOT a real test
+
+
+    min_prob = 0; //Pass everything
+    FindMutations::stats_t stats;
+    FindMutationsGetter find_mutation{min_prob, pedigree, test_param_1};
+    find_mutation(read_depths, ref_index, &stats);
+
+    MutationStats mutation_stats(min_prob);
+    find_mutation.calculate_mutation(read_depths, ref_index, mutation_stats);
+
+    BOOST_CHECK_EQUAL(stats.mup, mutation_stats.mup);
+    BOOST_CHECK_EQUAL(stats.llh, mutation_stats.llh);
+    BOOST_CHECK_EQUAL(stats.lld, mutation_stats.lld);
+    BOOST_CHECK_EQUAL(stats.mux, mutation_stats.mux);
+    BOOST_CHECK_EQUAL(stats.has_single_mut, mutation_stats.has_single_mut);
+    BOOST_CHECK_EQUAL(stats.mu1p, mutation_stats.mu1p);
+
+    BOOST_CHECK_EQUAL(stats.dnt, mutation_stats.dnt);
+    BOOST_CHECK_EQUAL(stats.dnl, mutation_stats.dnl);
+    BOOST_CHECK_EQUAL(stats.dnq, mutation_stats.dnq);
+
+    for (int i = 0; i < stats.posterior_probabilities.size(); ++i) {
+        boost_check_close_vector(stats.posterior_probabilities[i], mutation_stats.posterior_probabilities[i]);
+    }
+    for (int i = 2; i < stats.genotype_likelihoods.size(); ++i) {
+        boost_check_close_vector(stats.genotype_likelihoods[i], mutation_stats.genotype_likelihoods[i]);
+    }
+    for (int i = 2; i < stats.node_mup.size(); ++i) {
+        BOOST_CHECK_CLOSE(stats.node_mup[i], mutation_stats.node_mup[i], BOOST_CLOSE_THRESHOLD);
+    }
+
+    for (int i = 2; i < stats.node_mu1p.size(); ++i) {
+        BOOST_CHECK_CLOSE(stats.node_mu1p[i], mutation_stats.node_mu1p[i], BOOST_CLOSE_THRESHOLD);
+    }
+
+#if CALCULATE_ENTROPY == true
+    BOOST_CHECK_EQUAL(stats.dnc, mutation_stats.dnc);
+#endif
+
+}
+
+
+
+
+BOOST_AUTO_TEST_SUITE_END()
+

--- a/test/src/lib/test2_mutation_stats.cc
+++ b/test/src/lib/test2_mutation_stats.cc
@@ -1,0 +1,217 @@
+//
+// Created by steven on 2/9/16.
+//
+
+
+#define BOOST_TEST_MODULE dng::lib::mutation_stats
+
+#include <boost/test/unit_test.hpp>
+#include <iostream>
+
+#include <dng/mutation_stats.h>
+
+#include <boost_test_helper.h>
+#include <fixture/fixture_trio_workspace.h>
+
+
+
+const int NUM_TEST = 100;
+
+struct Fixture {
+    std::mt19937 random_gen_mt {1}; //seed = 1
+
+    std::string fixture;
+    std::uniform_real_distribution<double> rand_unif_log;
+    std::uniform_real_distribution<double> rand_unif;
+
+    double min_prob = 0.01;
+    Fixture(std::string s = "TestMutationStats") : fixture(s) {
+
+        rand_unif_log = std::uniform_real_distribution<double>(std::log(1e-20), 0);
+        rand_unif = std::uniform_real_distribution<double>(0,1);
+
+        BOOST_TEST_MESSAGE("set up fixture: " << fixture);
+    }
+
+    ~Fixture() {
+        BOOST_TEST_MESSAGE("tear down fixture: " << fixture);
+    }
+
+};
+
+void setup() { BOOST_TEST_MESSAGE("set up fun"); }
+
+void teardown() { BOOST_TEST_MESSAGE("tear down fun"); }
+
+
+
+BOOST_FIXTURE_TEST_SUITE(test_mutation_stats_suite, Fixture )
+
+BOOST_AUTO_TEST_CASE(test_set_mup, *utf::fixture(&setup, &teardown)) {
+
+    MutationStats stats (min_prob);
+
+    for (int t = 0; t <NUM_TEST; ++t) {
+
+        double ln_mut = rand_unif_log(random_gen_mt);
+        double ln_no_mut = rand_unif_log(random_gen_mt);
+
+        double prob_mu = std::exp(ln_mut);
+        double prob_no_mut = std::exp(ln_no_mut);
+
+        double expected = 1 - (prob_no_mut / prob_mu);
+        double expected_log =  - std::expm1(ln_no_mut - ln_mut);
+
+        stats.set_mutation_prob(ln_no_mut, ln_mut);
+        BOOST_CHECK_CLOSE(expected, expected_log, 0.01);
+        BOOST_CHECK_CLOSE(expected_log, stats.get_mutation_prob(), BOOST_CLOSE_THRESHOLD);
+    }
+
+    for (int t = 0; t <NUM_TEST; ++t) {
+
+        double prob_mu = rand_unif(random_gen_mt);
+        double prob_no_mut = rand_unif(random_gen_mt);
+
+        double ln_mu = std::log(prob_mu);
+        double ln_no_mut = std::log(prob_no_mut);
+
+        double expected = 1 - (prob_no_mut / prob_mu);
+
+        stats.set_mutation_prob(ln_no_mut, ln_mu);
+        BOOST_CHECK_CLOSE(expected, stats.get_mutation_prob(), BOOST_CLOSE_THRESHOLD);
+    }
+
+}
+
+
+BOOST_AUTO_TEST_CASE(test_set_node, *utf::fixture(&setup, &teardown)) {
+
+    MutationStats stats(min_prob);
+    int number_of_event = 20;
+    int first_non_founder = 5;
+
+    std::vector<double> event (number_of_event, hts::bcf::float_missing);
+
+    for (int t = first_non_founder; t < event.size(); ++t) {
+        event[t] = t;
+    }
+
+    double total = 0;
+    for (int i = first_non_founder; i < event.size(); ++i) {
+        total += event[i];
+    }
+
+    std::vector<float> expected_mu1p (number_of_event, hts::bcf::float_missing);
+    for (int i = first_non_founder; i < event.size(); ++i) {
+        expected_mu1p[i] = static_cast<float>(event[i]/total);
+    }
+
+    stats.set_node_mup(event, first_non_founder);
+    stats.set_node_mu1p(event, total, first_non_founder);
+
+    for (int i = 0; i < first_non_founder; ++i) {
+        BOOST_CHECK( bcf_float_is_missing(stats.node_mup[i]) );
+        BOOST_CHECK( bcf_float_is_missing(stats.node_mu1p[i]));
+    }
+
+    for (int i = first_non_founder; i < event.size(); ++i) {
+        BOOST_CHECK_EQUAL(i, stats.node_mup[i]);
+        BOOST_CHECK_EQUAL(expected_mu1p[i], stats.node_mu1p[i]);
+    }
+
+}
+
+
+BOOST_AUTO_TEST_CASE(test_record, *utf::fixture(&setup, &teardown)) {
+    BOOST_TEST_MESSAGE("Not yet implemented!");
+    //TODO: implement check on record_info/stats, hts::bcf::Variant
+    // record_single_mutation_stats(hts::bcf::Variant &record){
+}
+
+
+BOOST_AUTO_TEST_SUITE_END()
+
+
+BOOST_FIXTURE_TEST_SUITE(test_mutation_stats_suite2, TrioWorkspace )
+
+BOOST_AUTO_TEST_CASE(test_set_posterior_probabilities, *utf::fixture(&setup, &teardown)) {
+
+
+
+    dng::IndividualVector expected_probs;
+    expected_probs.reserve(workspace.num_nodes);
+
+    for (int i = 0; i < workspace.num_nodes; ++i) {
+        double sum = 0;
+        for (int j = 0; j < 10; ++j) {
+            expected_probs[i][j] = workspace.upper[i][j] * workspace.lower[i][j];
+            sum += expected_probs[i][j];
+        }
+        expected_probs[i] /= sum;
+    }
+
+    MutationStats stats (min_prob);
+    stats.set_posterior_probabilities(workspace);
+    for (int i = 0; i < workspace.num_nodes; ++i) {
+        boost_check_close_vector(expected_probs[i], stats.inspect_posterior_at(i));
+
+    }
+
+}
+
+
+BOOST_AUTO_TEST_CASE(test_genotype_stats, *utf::fixture(&setup, &teardown)) {
+
+
+    FindMutationsGetter find_mutation{min_prob, pedigree, test_param_1};
+    MutationStats stats(min_prob);
+
+    find_mutation.calculate_mutation(read_depths, ref_index, stats);
+
+    const int acgt_to_refalt_allele[] = {-1, 2, 0, 1, -1};
+    const int refalt_to_acgt_allele[5] = {2, 3, 1, -1, -1};
+    const uint32_t n_alleles = 3;
+    const std::size_t ref_index = 2;
+    const std::size_t num_nodes = 5;
+    const std::size_t library_start = 2;
+
+    std::vector<float> expected_gp_scores{
+            0.999833, 0.000167058, 1.78739e-12, 2.75325e-11, 3.57372e-16, 4.51356e-20,
+            0.984574, 0.0154262, 1.66835e-10, 9.77602e-12, 1.67414e-14, 1.58815e-20,
+            0.868225, 0.131775, 7.45988e-16, 1.99601e-09, 2.97932e-17, 3.704e-26,
+            0.999837, 0.000163186, 2.11375e-15, 2.7779e-11, 4.22658e-19, 5.33792e-23,
+            0.984578, 0.0154223, 6.97054e-14, 9.45085e-12, 6.98069e-18, 2.94856e-24
+    };
+    std::vector<float> expected_gl_scores{
+            NAN, NAN, NAN, NAN, NAN, NAN,
+            NAN, NAN, NAN, NAN, NAN, NAN,
+            -6.74046,0,-6.07991,-7.58973,-7.5555,-15.93,
+            0,-6.64246,-17.5301,-6.64246,-17.5301,-17.5301,
+            0,-4.667,-16.0119,-7.10524,-16.3122,-18.7879
+    };
+    std::vector<int> expected_best_genotype {2, 2, 2, 2, 2, 2, 2, 2, 2, 2};
+    std::vector<int> expected_genotype_qualities {38, 18, 9, 38, 18};
+
+
+    stats.set_genotype_related_stats(acgt_to_refalt_allele, refalt_to_acgt_allele,
+                                     n_alleles, ref_index, num_nodes, library_start);
+
+    boost_check_close_vector(expected_gp_scores, stats.gp_scores);
+    boost_check_equal_vector(expected_best_genotype, stats.best_genotypes);
+    boost_check_equal_vector(expected_genotype_qualities, stats.genotype_qualities);
+
+    BOOST_CHECK_EQUAL(expected_gl_scores.size(), stats.gl_scores.size());
+    for (int i = 0; i < expected_gl_scores.size(); ++i) {
+        if( isnan(expected_gl_scores[i]) ){
+            BOOST_CHECK( bcf_float_is_missing(stats.gl_scores[i]) );
+        }
+        else{
+            BOOST_CHECK_CLOSE(expected_gl_scores[i], stats.gl_scores[i], BOOST_CLOSE_THRESHOLD);
+        }
+    }
+
+
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+

--- a/test/src/lib/test2_peeling.cpp
+++ b/test/src/lib/test2_peeling.cpp
@@ -15,7 +15,7 @@
 
 #include <dng/peeling.h>
 
-#include "boost_test_helper.h"
+#include <boost_test_helper.h>
 
 //#include <boost/test/data/test_case.hpp>
 ////#include <boost/test/data/monomorphic.hpp>
@@ -235,8 +235,8 @@ BOOST_FIXTURE_TEST_SUITE(test_peeling_suite, Fx)
             dng::peel::up_fast(workspace, family, full_matrix);
             GenotypeArray result_fast = workspace.lower[0];
 
-            boost_check_array(expected, result, 10);
-            boost_check_array(expected_fast, result_fast, 10);
+            boost_check_close_vector(expected, result, 10);
+            boost_check_close_vector(expected_fast, result_fast, 10);
 
         }
     }
@@ -292,8 +292,8 @@ BOOST_FIXTURE_TEST_SUITE(test_peeling_suite, Fx)
             GenotypeArray result_fast = workspace.lower[0];
 
 
-            boost_check_array(expected, result, 10);
-            boost_check_array(expected_fast, result_fast, 10);
+            boost_check_close_vector(expected, result, 10);
+            boost_check_close_vector(expected_fast, result_fast, 10);
 
 
 
@@ -348,8 +348,8 @@ BOOST_FIXTURE_TEST_SUITE(test_peeling_suite, Fx)
             dng::peel::to_mother_fast(workspace, family, full_matrix);
             GenotypeArray result_fast = workspace.lower[1];
 
-            boost_check_array(expected, result, 10);
-            boost_check_array(expected_fast, result_fast, 10);
+            boost_check_close_vector(expected, result, 10);
+            boost_check_close_vector(expected_fast, result_fast, 10);
 
 
         }
@@ -414,8 +414,8 @@ BOOST_FIXTURE_TEST_SUITE(test_peeling_suite, Fx)
             GenotypeArray result_fast = workspace.upper[2];
 
 
-            boost_check_array(expected, result, 10);
-            boost_check_array(expected_fast, result_fast, 10);
+            boost_check_close_vector(expected, result, 10);
+            boost_check_close_vector(expected_fast, result_fast, 10);
 
         }
     }


### PR DESCRIPTION
Class FindMutation - Refactor out from call.cc to allow more testings.
    - calculate_mutation() function act as a drop-in replacement to the current operator(), which has less control. (rename it later)
    - This class will be extended to calculate different inheritance patterns.
    - Some calculation can be turn off if users don't want all stats.
    - src/helpers/find_mutation_helper: This exist to make testing easier only, which can be moved to else where. Or expose non public member/field/functions in a different way (e.g. friends).

Class MutationStats - Calculate and store stats (ready to output to hts::bcf::Variant). Some calculations from FindMutation and call.cc had been moved here. Later on will have switches allow users only output a subsets of stats. Still working on moving some counts related stats from call.cc to here.

call.cc - NO functional change at this PR. Several TODO tags in place, ready to replace it with these class above in the next refactoring cycle. Some stats calculation will be moved to MutationStats, still working the difference between variant/sequence data.

test/src/fixture/\* - Collection of fixtures can be used in multiple boost_tests.
