### PR TITLE
Update Pedigree class (pedigree_v2) and test files. 

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,6 +6,7 @@ INCLUDE_DIRECTORIES(BEFORE "${CMAKE_CURRENT_BINARY_DIR}")
 INCLUDE_DIRECTORIES(BEFORE "${CMAKE_CURRENT_SOURCE_DIR}/include")
 INCLUDE_DIRECTORIES(BEFORE "${CMAKE_CURRENT_SOURCE_DIR}/dnm")
 
+
 ADD_EXECUTABLE(dng-call
   dng-call.cc
   lib/call.cc lib/likelihood.cc lib/newick.cc lib/pedigree.cc lib/peeling.cc

--- a/src/include/dng/pedigree.h
+++ b/src/include/dng/pedigree.h
@@ -110,7 +110,7 @@ public:
     size_t num_nodes() const { return num_nodes_; }
     std::pair<size_t, size_t> library_nodes() const { return {first_library_, num_nodes_}; }
 
-    bool Equal(Pedigree &other_ped);
+    bool equal(Pedigree &other_ped);
     
 protected:
     // node structure:

--- a/src/include/dng/pedigree.h
+++ b/src/include/dng/pedigree.h
@@ -30,6 +30,7 @@
 #include <dng/newick.h>
 #include <dng/read_group.h>
 #include <dng/peeling.h>
+#include <utils/assert_utils.h>
 
 namespace dng {
 
@@ -109,6 +110,8 @@ public:
     size_t num_nodes() const { return num_nodes_; }
     std::pair<size_t, size_t> library_nodes() const { return {first_library_, num_nodes_}; }
 
+    bool Equal(Pedigree &other_ped);
+    
 protected:
     // node structure:
     // founder germline, non-founder germline, somatic, library

--- a/src/include/dng/pedigree_v2.h
+++ b/src/include/dng/pedigree_v2.h
@@ -95,7 +95,7 @@ public:
     bool Construct(const io::Pedigree &pedigree, dng::ReadGroups &rgs, const InheritancePattern &pattern,
                    double mu, double mu_somatic, double mu_library);
 
-    bool Equal(Pedigree &other_ped);
+    bool equal(Pedigree &other_ped);
 
 
     const std::vector<peel::family_members_t>& inspect_family_members() const {

--- a/src/include/dng/pedigree_v2.h
+++ b/src/include/dng/pedigree_v2.h
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2014-2015 Reed A. Cartwright
+ * Authors:  Reed A. Cartwright <reed@cartwrig.ht>
+ *
+ * This file is part of DeNovoGear.
+ *
+ * DeNovoGear is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+#ifndef DNG_PEDIGREE_V2_H
+#define DNG_PEDIGREE_V2_H
+
+//#include <functional>
+//#include <cmath>
+//#include <array>
+
+//#include <dng/matrix.h>
+//#include <dng/io/ped.h>
+//#include <dng/newick.h>
+//#include <dng/read_group.h>
+//#include <dng/peeling.h>
+
+#include <dng/pedigree.h>
+namespace dng {
+
+class PedigreeV2 : public Pedigree {
+
+    typedef boost::property_map<Graph, boost::edge_type_t>::type PropEdgeType;
+    typedef boost::property_map<Graph, boost::edge_length_t>::type PropEdgeLength;
+    typedef boost::property_map<Graph, boost::vertex_label_t>::type PropVertexLabel;
+    typedef boost::property_map<Graph, boost::vertex_group_t>::type PropVertexGroup;
+    typedef boost::property_map<Graph, boost::vertex_index_t>::type PropVertexIndex;
+
+    typedef boost::property_map<Graph, boost::vertex_index_t>::type IndexMap;
+
+
+    typedef std::vector<std::vector<boost::graph_traits<dng::Graph>::edge_descriptor>> family_labels_t;
+//    auto edge_types = get(edge_type, pedigree_graph);
+//    auto lengths = get(edge_length, pedigree_graph);
+//    auto labels = get(vertex_label, pedigree_graph);
+//    auto groups = get(vertex_group, pedigree_graph);
+//    auto families = get(edge_family, pedigree_graph);
+//    // Add the labels for the germline nodes
+//
+
+
+    enum class InheritancePattern : int {
+        AUTOSOMAL = 0,
+        DEFAULT = 0,
+        MATERNAL = 1,
+        PATERNAL = 2,
+        X_LINKED = 3,
+        Y_LINKED = 4,
+        W_LINKED = 5,
+        Z_LINKED = 6,
+
+//        autosomal (the default)
+//        xlinked (females have 2 copies, males have 1; males transmit to daughters, not to sons)
+//        ylinked (males have 1 copy, only transmits it to sons)
+//        wlinked (females have 1 copy, only transmited to daughters)
+//        zlinked (males have 2 copies, females have 1; females transmit to sons, not to daughters)
+//        maternal (transmitted by mother to child)
+//        paternal (transmitter by father to child)
+    };
+
+    //TODO: struct FamilyInfo/Family structure.
+    //Op1: A struct to record info in each family. family_t and ops
+    //Op2: Another struct to group families together, include pivots and root?
+    enum class FamilyType : int {
+        PAIR = 2,
+        TRIO = 3
+    };
+    struct FamilyInfo {
+        FamilyType family_type;
+        family_labels_t family_labels;//(num_families);
+        std::vector<vertex_t> pivots;//(num_families, dummy_index);
+    };
+
+public:
+    bool Construct(const io::Pedigree &pedigree, dng::ReadGroups &rgs,
+                   double mu, double mu_somatic, double mu_library);
+
+    //TODO: Eventually replace with this, or pass inheritance with a different method
+    bool Construct(const io::Pedigree &pedigree, dng::ReadGroups &rgs, const InheritancePattern &pattern,
+                   double mu, double mu_somatic, double mu_library);
+
+    bool Equal(Pedigree &other_ped);
+
+
+    const std::vector<peel::family_members_t>& inspect_family_members() const {
+        return family_members_;
+    }
+    const std::vector<decltype(peel::op::NUM)>& inspect_peeling_ops() const {
+        return peeling_ops_;
+    };
+    const std::vector<decltype(peel::op::NUM)>& inspect_peeling_functions_ops() const {
+        return peeling_functions_ops_;
+    };
+//    // The original, simplified peeling operations
+//    std::vector<decltype(peel::op::NUM)> peeling_ops_;
+//    // The modified, "faster" operations
+//    std::vector<decltype(peel::op::NUM)> peeling_functions_ops_;
+//    // Array of functions that will be called to perform the peeling
+//    std::vector<peel::function_t> peeling_functions_;
+//    std::vector<peel::function_t> peeling_reverse_functions_;
+//
+//    // The arguments to a peeling operation
+//    std::vector<peel::family_members_t> family_members_;
+
+protected:
+
+
+    void ParseIoPedigree(dng::Graph &pedigree_graph, const dng::io::Pedigree &pedigree);
+
+    void AddLibrariesFromReadGroups(dng::Graph &pedigree_graph, const dng::ReadGroups &rgs,
+                                                PropVertexLabel &labels);
+
+    void ConnectSomaticToLibraries(dng::Graph &pedigree_graph, const ReadGroups &rgs,
+                                   const PropVertexLabel &labels);
+
+    void UpdateEdgeLengths(dng::Graph &pedigree_graph, double mu, double mu_somatic, double mu_library);
+
+    void SimplifyPedigree(dng::Graph &pedigree_graph, const PropEdgeType &edge_types, const PropEdgeLength &lengths);
+
+    void UpdateLabelsNodeIds(dng::Graph &pedigree_graph, dng::ReadGroups rgs, std::vector<size_t> &node_ids);
+
+    void EraseRemovedLibraries(dng::ReadGroups &rgs, std::vector<size_t> &node_ids);
+
+    void CreateFamiliesInfo(dng::Graph &pedigree_graph, family_labels_t &family_labels, std::vector<vertex_t> &pivots);
+
+    void CreatePeelingOps(dng::Graph &pedigree_graph, const std::vector<size_t> &node_ids,
+                          family_labels_t &family_labels, std::vector<vertex_t> &pivots);
+
+private:
+    void PrintDebugEdges(const std::string &prefix, const dng::Graph &pedigree_graph);
+
+
+    const vertex_t DUMMY_INDEX = 0;
+};
+
+}// namespace dng
+
+
+#endif // DNG_PEDIGREE_H

--- a/src/include/utils/assert_utils.h
+++ b/src/include/utils/assert_utils.h
@@ -1,0 +1,70 @@
+//
+// Created by steven on 1/29/16.
+//
+
+#ifndef DENOVOGEAR_ASSERT_UTILS_H
+#define DENOVOGEAR_ASSERT_UTILS_H
+
+#include <cassert>
+
+
+const double ASSERT_CLOSE_THRESHOLD = 1e-6;
+
+//TODO: HACK: FIXME:
+template<typename A, typename B>
+void AssertEqual(A expected, B actual) {
+    assert(expected == actual);
+};
+
+template<typename A>
+void AssertEqual(A expected, A actual) {
+    assert(expected == actual);
+};
+
+template<typename A>
+void AssertNear(A expected, A actual) {
+    if (!(expected == 0 && actual == 0)) {
+        assert(((expected - actual) / expected) < ASSERT_CLOSE_THRESHOLD);
+    }
+
+};
+
+//template<typename A>
+//void AssertVectorNear(A expected, A actual){
+//    AssertEqual(expected.size(), actual.size());
+//    for (int j = 0; j < expected.size(); ++j) {
+//        AssertNear(expected[j], actual[j]);
+//    }
+//};
+
+template<typename A, typename B>
+void AssertVectorEqual(A expected, B actual) {
+    AssertEqual(expected.size(), actual.size());
+    for (int j = 0; j < expected.size(); ++j) {
+        AssertEqual(expected[j], actual[j]);
+    }
+};
+
+
+template<typename A, typename B>
+void AssertVectorNear(A expected, B actual) {
+    AssertEqual(expected.size(), actual.size());
+    for (int j = 0; j < expected.size(); ++j) {
+        AssertNear(expected[j], actual[j]);
+    }
+};
+
+
+template<typename A>
+void AssertEigenMatrixNear(A expected, A actual) {
+    AssertEqual(expected.rows(), actual.rows());
+    AssertEqual(expected.cols(), actual.cols());
+    for (int j = 0; j < expected.rows(); ++j) {
+        for (int k = 0; k < expected.cols(); ++k) {
+            AssertNear(expected(j, k), actual(j, k));
+        }
+    }
+}
+
+
+#endif //DENOVOGEAR_ASSERT_UTILS_H

--- a/src/include/utils/assert_utils.h
+++ b/src/include/utils/assert_utils.h
@@ -10,60 +10,69 @@
 
 const double ASSERT_CLOSE_THRESHOLD = 1e-6;
 
+
 //TODO: HACK: FIXME:
 template<typename A, typename B>
-void AssertEqual(A expected, B actual) {
+void assert_equal(A expected, B actual) {
     assert(expected == actual);
 };
 
 template<typename A>
-void AssertEqual(A expected, A actual) {
+void assert_equal(A expected, A actual) {
     assert(expected == actual);
 };
 
 template<typename A>
-void AssertNear(A expected, A actual) {
+void assert_near(A expected, A actual) {
+
+#ifndef	NDEBUG
     if (!(expected == 0 && actual == 0)) {
         assert(((expected - actual) / expected) < ASSERT_CLOSE_THRESHOLD);
     }
-
+#endif
 };
 
 //template<typename A>
 //void AssertVectorNear(A expected, A actual){
-//    AssertEqual(expected.size(), actual.size());
+//    assert_equal(expected.size(), actual.size());
 //    for (int j = 0; j < expected.size(); ++j) {
 //        AssertNear(expected[j], actual[j]);
 //    }
 //};
 
 template<typename A, typename B>
-void AssertVectorEqual(A expected, B actual) {
-    AssertEqual(expected.size(), actual.size());
+void assert_equal_vector(A expected, B actual) {
+#ifndef	NDEBUG
+    assert_equal(expected.size(), actual.size());
     for (int j = 0; j < expected.size(); ++j) {
-        AssertEqual(expected[j], actual[j]);
+        assert_equal(expected[j], actual[j]);
     }
+#endif
 };
 
 
 template<typename A, typename B>
-void AssertVectorNear(A expected, B actual) {
-    AssertEqual(expected.size(), actual.size());
+void assert_near_vector(A expected, B actual) {
+#ifndef	NDEBUG
+    assert_equal(expected.size(), actual.size());
     for (int j = 0; j < expected.size(); ++j) {
-        AssertNear(expected[j], actual[j]);
+        assert_near(expected[j], actual[j]);
     }
+#endif
 };
 
 
 template<typename A>
-void AssertEigenMatrixNear(A expected, A actual) {
-    AssertEqual(expected.rows(), actual.rows());
-    AssertEqual(expected.cols(), actual.cols());
+void assert_near_eigen_matrix(A expected, A actual) {
+#ifndef	NDEBUG
+    assert_equal(expected.rows(), actual.rows());
+    assert_equal(expected.cols(), actual.cols());
     for (int j = 0; j < expected.rows(); ++j) {
         for (int k = 0; k < expected.cols(); ++k) {
-            AssertNear(expected(j, k), actual(j, k));
+            assert_near(expected(j, k), actual(j, k));
         }
     }
+#endif
 }
 
 

--- a/src/include/utils/boost_utils.h
+++ b/src/include/utils/boost_utils.h
@@ -5,6 +5,7 @@
 #ifndef DENOVOGEAR_BOOST_UTILS_H
 #define DENOVOGEAR_BOOST_UTILS_H
 
+#include <boost/range/iterator_range_core.hpp>
 namespace utils {
 
 

--- a/src/include/utils/boost_utils.h
+++ b/src/include/utils/boost_utils.h
@@ -1,0 +1,23 @@
+//
+// Created by steven on 2/4/16.
+//
+
+#ifndef DENOVOGEAR_BOOST_UTILS_H
+#define DENOVOGEAR_BOOST_UTILS_H
+
+namespace utils {
+
+
+// Helper function that mimics boost::istream_range
+template<class Elem, class Traits> inline
+boost::iterator_range <std::istreambuf_iterator<Elem, Traits>> istreambuf_range(
+        std::basic_istream <Elem, Traits> &in) {
+    return boost::iterator_range < std::istreambuf_iterator < Elem, Traits >> (
+            std::istreambuf_iterator<Elem, Traits>(in),
+                    std::istreambuf_iterator<Elem, Traits>());
+}
+
+
+} // namespace utils
+
+#endif //DENOVOGEAR_BOOST_UTILS_H

--- a/src/lib/pedigree.cc
+++ b/src/lib/pedigree.cc
@@ -657,3 +657,66 @@ std::vector<std::string> dng::Pedigree::BCFHeaderLines() const {
     }
     return ret;
 }
+
+
+bool dng::Pedigree::Equal(dng::Pedigree &other_ped) {
+
+    AssertEqual(num_nodes_, other_ped.num_nodes());
+    AssertEqual(first_founder_, other_ped.first_founder_);
+    AssertEqual(first_nonfounder_, other_ped.first_nonfounder_);
+    AssertEqual(first_somatic_, other_ped.first_somatic_);
+    AssertEqual(first_library_, other_ped.first_library_);
+
+    auto other_labels = other_ped.labels();
+    AssertVectorEqual(labels_, other_labels);
+
+    //TODO: How to iterate through struct? without create another function in struct?
+    auto other_transitions = other_ped.transitions();
+    for (int j = 0; j < transitions_.size(); ++j) {
+        assert(transitions_[j].type == other_transitions[j].type);
+        assert(transitions_[j].parent1 == other_transitions[j].parent1);
+        assert(transitions_[j].parent2 == other_transitions[j].parent2);
+        assert(transitions_[j].length1 == other_transitions[j].length1);
+        assert(transitions_[j].length2 == other_transitions[j].length2);
+    }
+
+    auto other_roots = other_ped.roots_;
+    AssertVectorEqual(roots_, other_roots);
+
+    auto other_peeling_ops = other_ped.peeling_ops_;
+    AssertVectorEqual(peeling_ops_, other_peeling_ops);
+
+    auto other_peeling_function_ops = other_ped.peeling_functions_ops_;
+    AssertVectorEqual(peeling_functions_ops_, other_peeling_function_ops);
+
+
+    auto other_peeling_functions = other_ped.peeling_functions_;
+    for (int j = 0; j < peeling_functions_.size() - 1; ++j) {
+        int op_index = peeling_functions_ops_[j];
+
+        assert(dng::peel::functions[op_index] ==
+               other_peeling_functions[j]); //Check against expected dng::peel::functions
+        assert(peeling_functions_[j] == other_peeling_functions[j]); //Check against others
+
+    }
+
+    auto other_peeling_reverse_functions = other_ped.peeling_reverse_functions_;
+    for (int j = 0; j < peeling_reverse_functions_.size() - 1; ++j) {
+        int op_index = peeling_functions_ops_[j];
+        assert(dng::peel::reverse_functions[op_index] ==
+               other_peeling_reverse_functions[j]); //Check against expected dng::peel::functions
+        assert(peeling_reverse_functions_[j] == other_peeling_reverse_functions[j]); //Check against others
+
+    }
+
+
+    auto other_family_members_ = other_ped.family_members_;
+    AssertEqual(family_members_.size(), other_family_members_.size());
+    for (int k = 0; k < family_members_.size(); ++k) {
+        AssertVectorEqual(family_members_[k], other_family_members_[k]);
+    }
+
+    return true;
+
+
+}

--- a/src/lib/pedigree.cc
+++ b/src/lib/pedigree.cc
@@ -659,16 +659,16 @@ std::vector<std::string> dng::Pedigree::BCFHeaderLines() const {
 }
 
 
-bool dng::Pedigree::Equal(dng::Pedigree &other_ped) {
+bool dng::Pedigree::equal(dng::Pedigree &other_ped) {
 
-    AssertEqual(num_nodes_, other_ped.num_nodes());
-    AssertEqual(first_founder_, other_ped.first_founder_);
-    AssertEqual(first_nonfounder_, other_ped.first_nonfounder_);
-    AssertEqual(first_somatic_, other_ped.first_somatic_);
-    AssertEqual(first_library_, other_ped.first_library_);
+    assert_equal(num_nodes_, other_ped.num_nodes());
+    assert_equal(first_founder_, other_ped.first_founder_);
+    assert_equal(first_nonfounder_, other_ped.first_nonfounder_);
+    assert_equal(first_somatic_, other_ped.first_somatic_);
+    assert_equal(first_library_, other_ped.first_library_);
 
     auto other_labels = other_ped.labels();
-    AssertVectorEqual(labels_, other_labels);
+    assert_equal_vector(labels_, other_labels);
 
     //TODO: How to iterate through struct? without create another function in struct?
     auto other_transitions = other_ped.transitions();
@@ -681,13 +681,13 @@ bool dng::Pedigree::Equal(dng::Pedigree &other_ped) {
     }
 
     auto other_roots = other_ped.roots_;
-    AssertVectorEqual(roots_, other_roots);
+    assert_equal_vector(roots_, other_roots);
 
     auto other_peeling_ops = other_ped.peeling_ops_;
-    AssertVectorEqual(peeling_ops_, other_peeling_ops);
+    assert_equal_vector(peeling_ops_, other_peeling_ops);
 
     auto other_peeling_function_ops = other_ped.peeling_functions_ops_;
-    AssertVectorEqual(peeling_functions_ops_, other_peeling_function_ops);
+    assert_equal_vector(peeling_functions_ops_, other_peeling_function_ops);
 
 
     auto other_peeling_functions = other_ped.peeling_functions_;
@@ -711,9 +711,9 @@ bool dng::Pedigree::Equal(dng::Pedigree &other_ped) {
 
 
     auto other_family_members_ = other_ped.family_members_;
-    AssertEqual(family_members_.size(), other_family_members_.size());
+    assert_equal(family_members_.size(), other_family_members_.size());
     for (int k = 0; k < family_members_.size(); ++k) {
-        AssertVectorEqual(family_members_[k], other_family_members_[k]);
+        assert_equal_vector(family_members_[k], other_family_members_[k]);
     }
 
     return true;

--- a/src/lib/pedigree_v2.cc
+++ b/src/lib/pedigree_v2.cc
@@ -1,0 +1,910 @@
+/*
+ * Copyright (c) 2014-2015 Reed A. Cartwright
+ * Authors:  Reed A. Cartwright <reed@cartwrig.ht>
+ *
+ * This file is part of DeNovoGear.
+ *
+ * DeNovoGear is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <dng/pedigree_v2.h>
+#include <dng/graph.h>
+#include <dng/mutation.h>
+
+#include <algorithm>
+
+#include <boost/graph/adjacency_list.hpp>
+#include <boost/graph/biconnected_components.hpp>
+#include <boost/graph/connected_components.hpp>
+#include <boost/graph/undirected_dfs.hpp>
+#include <boost/property_map/vector_property_map.hpp>
+#include <boost/range/algorithm/find.hpp>
+#include <boost/range/algorithm/replace.hpp>
+#include <boost/range/algorithm/for_each.hpp>
+#include <boost/algorithm/cxx11/any_of.hpp>
+#include <boost/timer/timer.hpp>
+#include <utils/assert_utils.h>
+
+
+#define DNG_GL_PREFIX "GL-"
+#define DNG_SM_PREFIX "SM-" // define also in newick.cc
+#define DNG_LB_PREFIX "LB-"
+
+/*
+RULES FOR LINKING READ GROUPS TO PEOPLE.
+
+0) Read all read groups in bam files. Map RG to Library to Sample.
+
+1) If tissue information is present, build a tissue tree connecting samples
+   to zygotic genotypes.  Build mutation matrices for every unique branch
+   length.
+
+2) If no tissue information is present in pedigree, check to see if there is a
+   sample with the same label as the individual.  If so, connect that sample to
+   the individual with a somatic branch of length 1.
+
+3) If a sample has multiple libraries, connect the libraries to sample with a
+   library branch.
+
+4) If a library has multiple read-groups, concat the read-groups.
+
+*/
+
+//#define DEBUG_VERBOSE 0
+
+bool dng::PedigreeV2::Construct(const io::Pedigree &pedigree,
+                                dng::ReadGroups &rgs,
+                                double mu, double mu_somatic, double mu_library) {
+    using namespace boost;
+    using namespace std;
+
+
+//    graph_traits<Graph>::edge_iterator ei, ei_end;
+//    graph_traits<Graph>::vertex_iterator vi, vi_end;
+
+//Maybe not here
+//    typedef property_map<Graph, vertex_index_t>::type IndexMap;
+
+    // Setup counts //const??
+    std::size_t num_members = pedigree.member_count();
+//    const vertex_t dummy_index = 0;
+
+    // Count the founders
+    first_founder_ = 0; //Can this be something other than 0??
+    first_somatic_ = num_members;
+
+    for (first_nonfounder_ = first_founder_; first_nonfounder_ < num_members;
+         ++first_nonfounder_) {
+        if (pedigree.table()[first_nonfounder_].dad != 0 &&
+            pedigree.table()[first_nonfounder_].mom != 0) {
+            break;
+        }
+    }
+//    std::size_t num_libraries = rgs.libraries().size(); //??const??
+
+    // Construct a graph of the pedigree and somatic information
+    Graph pedigree_graph(num_members);
+
+    PrintDebugEdges("========== VERISON 2 =========\ninit pedigree", pedigree_graph);
+
+    auto edge_types = get(edge_type, pedigree_graph);
+    auto lengths = get(edge_length, pedigree_graph);
+    auto labels = get(vertex_label, pedigree_graph);
+//    auto groups = get(vertex_group, pedigree_graph);
+//    auto families = get(edge_family, pedigree_graph);
+    // Add the labels for the germline nodes
+
+    labels[0] = DNG_GL_PREFIX "unknown";
+    for (size_t i = 1; i < num_members; ++i) {
+        labels[i] = DNG_GL_PREFIX + pedigree.name(i);
+    }
+    PrintDebugEdges("Start", pedigree_graph);
+    // Go through rows and construct the pedigree part.
+
+    ParseIoPedigree(pedigree_graph, pedigree);
+    AddLibrariesFromReadGroups(pedigree_graph, rgs, labels);
+
+    vector<size_t> node_ids(num_nodes_, -1);//num_nodes used twice for different contex
+
+    UpdateEdgeLengths(pedigree_graph, mu, mu_somatic, mu_library);
+    SimplifyPedigree(pedigree_graph, edge_types, lengths);
+    UpdateLabelsNodeIds(pedigree_graph, rgs, node_ids);
+
+    PrintDebugEdges("After update position()", pedigree_graph);
+
+    // Reset Family Information
+    roots_.clear();
+    roots_.reserve(16);
+    family_members_.clear();
+    family_members_.reserve(128);
+    peeling_ops_.clear();
+    peeling_ops_.reserve(128);
+
+
+    family_labels_t family_labels;//(num_families);
+    vector<vertex_t> pivots;//(num_families, dummy_index);
+    CreateFamiliesInfo(pedigree_graph, family_labels, pivots);
+
+/*TODO: Relate to issue: Support different inheritance patterns #54
+TODO: cont. parse inheritance_pattern and create different peelingOps.
+TODO: cont. Everything else should stay the same (can be simplified, but might not be necessary)
+*/
+    InheritancePattern inheritance_pattern = InheritancePattern::DEFAULT ;//
+    if (inheritance_pattern == InheritancePattern::DEFAULT) {
+        //TODO: Most things in CreatePeelingOps() can be shared between InheritancePattern
+        CreatePeelingOps(pedigree_graph, node_ids, family_labels, pivots);
+        ConstructPeelingMachine();
+    }
+    else {
+        std::cerr << "You should never get here, other inheritance pattern not implemented yet!! EXTI!" << std::endl;
+        std::exit(9);
+    }
+
+#ifdef DNG_DEVEL
+    PrintMachine(cerr);
+#else
+    //PrintMachine(cerr);
+#endif
+
+    return true;
+}
+
+
+void dng::PedigreeV2::ParseIoPedigree(dng::Graph &pedigree_graph, const dng::io::Pedigree &pedigree) {
+
+    for (auto &row : pedigree.table()) {
+
+        vertex_t child = row.child;
+        vertex_t dad = row.dad;
+        vertex_t mom = row.mom;
+#ifdef DEBUG_VERBOSE
+
+        std::cout << "===Child_Dad_MoM: " << child << "\t" << dad << "\t" << mom << std::endl;
+#endif
+        if (child == 0) {
+            continue;
+        }
+        if (dad == mom && dad != 0) {
+            // Selfing is not supported
+            throw std::runtime_error("Unable to construct peeler for pedigree; selfing is not supported");
+//                                             "possible non-zero-loop pedigree.");
+        }
+
+        // check to see if mom and dad have been seen before
+        auto id = edge(dad, mom, pedigree_graph);
+        if (!id.second) {
+            add_edge(dad, mom, EdgeType::Spousal, pedigree_graph);
+            //Connect dad-mom to make a dependend trio
+        }
+#ifdef DEBUG_VERBOSE
+
+        std::cout << "===after spoesal: V E:" << num_vertices(pedigree_graph) << "\t" << num_edges(pedigree_graph) <<
+        std::endl;
+#endif
+                // add the meiotic edges
+        add_edge(mom, child, {EdgeType::Meiotic, 1.0f}, pedigree_graph);
+        add_edge(dad, child, {EdgeType::Meiotic, 1.0f}, pedigree_graph);
+#ifdef DEBUG_VERBOSE
+
+        std::cout << "===after add_edge: V E:" << num_vertices(pedigree_graph) << "\t" << num_edges(pedigree_graph) <<
+        std::endl;
+        std::cout << "===Child_Dad_MoM: " << child << "\t" << dad << "\t" << mom << std::endl;
+#endif
+
+        // Process newick file
+        // TODO: should newick::parse add edge? or do it here?
+        int res = newick::parse(row.sample_tree, child, pedigree_graph);
+#ifdef DEBUG_VERBOSE
+        std::cout << "===after parse: V E:" << num_vertices(pedigree_graph) << "\t" << num_edges(pedigree_graph) <<
+        std::endl;
+#endif
+        if (res == 0) {
+            // this line has a blank somatic line, so use the name from the pedigree
+            vertex_t v = add_vertex(DNG_SM_PREFIX + pedigree.name(child), pedigree_graph);
+            add_edge(child, v, {EdgeType::Mitotic, 1.0f}, pedigree_graph);
+#ifdef DEBUG_VERBOSE
+            std::cout << "===add res==0: " << child << "\t" << v << "\t" << pedigree.name(child) << std::endl;
+#endif
+        } else if (res == -1) {
+            throw std::runtime_error("unable to parse somatic data for individual '" +
+                                     pedigree.name(child) + "'.");
+        }
+#ifdef DEBUG_VERBOSE
+
+        std::cout << "Loop END: V E:" << num_vertices(pedigree_graph) << "\t" << num_edges(pedigree_graph) << std::endl;
+#endif
+    }
+    PrintDebugEdges("Parsed io::pedigree, before cleas_vertex dummy", pedigree_graph);
+    clear_vertex(DUMMY_INDEX, pedigree_graph);
+}
+
+
+void dng::PedigreeV2::AddLibrariesFromReadGroups(Graph &pedigree_graph, const dng::ReadGroups &rgs,
+                                                 PropVertexLabel &labels) {
+
+    dng::PedigreeV2::PrintDebugEdges("After clear_vertex()", pedigree_graph);
+
+    first_library_ = num_vertices(pedigree_graph);
+
+    // Add library nodes to graph
+    for (auto &&a : rgs.libraries()) {
+        dng::vertex_t v = add_vertex(pedigree_graph);
+        labels[v] = DNG_LB_PREFIX + a;
+#ifdef DEBUG_VERBOSE
+        std::cout << "Add lib: " << labels[v] << std::endl;
+#endif
+    }
+    dng::PedigreeV2::PrintDebugEdges("After add libs", pedigree_graph);
+
+    dng::PedigreeV2::ConnectSomaticToLibraries(pedigree_graph, rgs, labels);
+    num_nodes_ = num_vertices(pedigree_graph);
+
+    dng::PedigreeV2::PrintDebugEdges("After connect somatic", pedigree_graph);
+}
+
+void dng::PedigreeV2::ConnectSomaticToLibraries(dng::Graph &pedigree_graph, const ReadGroups &rgs,
+                                                const PropVertexLabel &labels) {
+
+    const size_t STRLEN_DNG_SM_PREFIX = strlen(DNG_SM_PREFIX);
+
+    for (vertex_t v = (vertex_t) first_somatic_; v < first_library_; ++v) {
+        if (labels[v].empty()) {
+            continue;
+        }
+        //using orders from vcf files rgs
+
+        auto r = rgs.data().get<rg::sm>().equal_range(labels[v].c_str() + STRLEN_DNG_SM_PREFIX);
+        for (; r.first != r.second; ++r.first) {
+            vertex_t w = first_library_ + rg::index(rgs.libraries(), r.first->library);
+            if (!edge(v, w, pedigree_graph).second) {
+                add_edge(v, w, {EdgeType::Library, 1.0f}, pedigree_graph);
+            }
+        }
+    }
+}
+
+
+
+void dng::PedigreeV2::UpdateEdgeLengths(dng::Graph &pedigree_graph, double mu, double mu_somatic, double mu_library) {
+    boost::graph_traits<dng::Graph>::edge_iterator ei, ei_end;
+    auto edge_types = get(boost::edge_type, pedigree_graph);
+    auto lengths = get(boost::edge_length, pedigree_graph);
+
+    for (tie(ei, ei_end) = edges(pedigree_graph); ei != ei_end; ++ei) {
+        if (edge_types[*ei] == dng::graph::EdgeType::Meiotic) {
+            lengths[*ei] *= mu;
+        } else if (edge_types[*ei] == dng::graph::EdgeType::Mitotic) {
+            lengths[*ei] *= mu_somatic;
+        } else if (edge_types[*ei] == dng::graph::EdgeType::Library) {
+            lengths[*ei] *= mu_library;
+        }
+   }
+#ifdef DEBUG_VERBOSE
+
+    std::cout << "Founder, Non_F, Lib, Somatic: " << this->first_founder_ << "\t" << this->first_nonfounder_ << "\t" <<
+    this->first_library_ << "\t" << this->first_somatic_ << std::endl;
+#endif
+}
+
+void dng::PedigreeV2::SimplifyPedigree(dng::Graph &pedigree_graph, const PropEdgeType &edge_types,
+                                       const PropEdgeLength &lengths) {
+
+//property_map<Graph, edge_type_t>::type edge_types = get(boost::edge_type, pedigree_graph);
+//property_map<Graph, edge_length_t>::type lengths = get(boost::edge_length, pedigree_graph);
+
+//    auto edge_types = get(boost::edge_type, pedigree_graph);
+//    auto lengths = get(edge_length, pedigree_graph);
+//    auto labels = get(vertex_label, pedigree_graph);
+//    auto groups = get(vertex_group, pedigree_graph);
+//    auto families = get(edge_family, pedigree_graph);
+
+//    std::cout << edge_types[0] << std::endl;
+//    testE(edge_types, pedigree_graph);
+
+    for (auto w = first_library_; w > first_founder_; --w) {
+        vertex_t v = (vertex_t) (w - 1);
+        size_t children = 0, ancestors = 0, spouses = 0;
+
+        auto rng = out_edges(v, pedigree_graph);
+
+        for (auto it = rng.first; it != rng.second; ++it) {
+            edge_t e = *it;
+            if (edge_types[e] == EdgeType::Spousal) {
+                spouses += 1;
+            } else if (target(e, pedigree_graph) > v) {
+                children += 1;
+            } else {
+                ancestors += 1;
+            }
+        }
+        if (children == 0) {
+            // this node has no descendants
+            clear_vertex(v, pedigree_graph);
+        } else if (children >= 2 || spouses != 0) {
+            /*noop*/;
+        }
+        else {
+            edge_t edge_trio[3];// TODO: How "wrong" does the graph has to be to hove ancestor>2? should be impossible (at least logically)
+            vertex_t vertex_trio[3];//
+            int child_index = ancestors;
+            for (size_t j = 0; j <= ancestors; ++j) {
+                edge_trio[j] = *(rng.first + j);
+                vertex_trio[j] = target(edge_trio[j], pedigree_graph);
+            }
+            for (size_t p = 0; p < child_index; ++p) {
+                if (vertex_trio[child_index] < vertex_trio[p]) {
+                    boost::swap(vertex_trio[child_index], vertex_trio[p]);
+                    boost::swap(edge_trio[child_index], edge_trio[p]);
+                }
+                add_edge(vertex_trio[p], vertex_trio[child_index],
+                         {edge_types[edge_trio[p]], lengths[edge_trio[p]] + lengths[edge_trio[child_index]]},
+                         pedigree_graph);
+
+            }
+            clear_vertex(v, pedigree_graph);
+#ifdef DEBUG_VERBOSE
+
+            std::cout << "CleanV2 anc==" << ancestors << " remove: " << v << std::endl;
+#endif
+        }
+
+    }
+    PrintDebugEdges("After SimplifyPedigree", pedigree_graph);
+
+}
+
+void dng::PedigreeV2::UpdateLabelsNodeIds(dng::Graph &pedigree_graph, dng::ReadGroups rgs,
+                                          std::vector<size_t> &node_ids) {
+
+    auto labels = get(boost::vertex_label, pedigree_graph);
+
+
+    labels_.clear();
+    labels_.reserve(128);
+    size_t vid = 0;
+    for (std::size_t u = 0; u < num_nodes_; ++u) {
+        if (out_degree(u, pedigree_graph) == 0) {
+            continue;
+        }
+        if (!labels[u].empty()) {
+            labels_.push_back(labels[u]);
+        } else {
+            labels_.push_back(DNG_SM_PREFIX "unnamed_node_" + util::to_pretty(vid));
+        }
+        node_ids[u] = vid++;
+    }
+    num_nodes_ = vid;
+#ifdef DEBUG_VERBOSE
+
+    std::cout << num_nodes_ << std::endl;
+    std::cout << "After remove some nodes: new V labels_sizse: " << vid << "\t" << labels_.size() << std::endl;
+    for (auto item : labels_) {
+        std::cout << item << std::endl;
+    }
+    std::cout << "node_ids:" << std::endl;
+    for (int j = 0; j < node_ids.size(); ++j) {
+        std::cout << j << " -> " << node_ids[j] << std::endl;
+    }
+#endif
+    EraseRemovedLibraries(rgs, node_ids);//TODO: Do we really need this??
+
+
+//    size_t vid = num_nodes_;
+    auto update_position = [&node_ids, vid](size_t pos) -> size_t {
+        for (; pos < node_ids.size() && node_ids[pos] == -1; ++pos)
+            /*noop*/;
+        return (pos < node_ids.size()) ? node_ids[pos] : vid;
+    };
+
+    first_founder_ = update_position(first_founder_);
+    first_nonfounder_ = update_position(first_nonfounder_);
+    first_somatic_ = update_position(first_somatic_);
+    first_library_ = update_position(first_library_);
+
+    PrintDebugEdges("Test", pedigree_graph);
+
+
+}
+
+
+//
+//void dng::Pedigree::ConstructPeelingMachine() {
+//    using namespace dng::peel;
+//    peeling_functions_.clear();
+//    peeling_functions_.reserve(peeling_ops_.size());
+//    peeling_functions_ops_.reserve(peeling_ops_.size());
+//    peeling_reverse_functions_.reserve(peeling_ops_.size());
+//    std::vector<std::size_t> lower_written(num_nodes_, -1);
+//    for(std::size_t i = 0 ; i < peeling_ops_.size(); ++i) {
+//        auto a = peeling_ops_[i];
+//        const auto &fam = family_members_[i];
+//        auto w = fam[info[a].writes_to];
+//        int b = a;
+//        switch(a) {
+//        case op::DOWN:
+//            // If the lower of the parent has never been written to, we can use the fast version
+//            b = (lower_written[fam[0]] == -1) ? op::UPFAST + b : b;
+//            break;
+//        case op::TOCHILD:
+//            // If the we only have one child, we can use the fast version
+//            b = (fam.size() == 3) ? op::UPFAST + b : b;
+//            break;
+//        case op::TOMOTHER:
+//        case op::TOFATHER:
+//        case op::UP:
+//            // If the lower of the destination has never been written to, we can use the fast version
+//            b = (lower_written[w] == -1) ? op::UPFAST + b : b;
+//            break;
+//        default:
+//            assert(false); // should never get here
+//            break;
+//        }
+//        peeling_functions_ops_.push_back(static_cast<decltype(op::NUM)>(b));
+//        peeling_functions_.push_back(functions[b]);
+//        peeling_reverse_functions_.push_back(reverse_functions[b]);
+//
+//        // If the operation writes to a lower value, make note of it
+//        if(info[a].writes_lower) {
+//            lower_written[w] = i;
+//        }
+//    }
+//}
+
+//
+
+//template <class Config>
+//testV(typename Config::vertex_descriptor v){
+//
+//    std::cout <<"V: "<< v<< std::endl;
+//};
+
+//detail {
+
+//=========================================================================
+// Adjacency List Generator
+
+//template <class Graph, class VertexListS, class OutEdgeListS,
+//        class DirectedS, class VertexProperty, class EdgeProperty,
+//        class GraphProperty, class EdgeListS>
+//struct adj_list_gen
+//using namespace boost;
+
+//typedef boost::detail::edge_descriptor EE;
+//template <class Config>
+//void testE(EdgeProperties e, dng::Graph &pedigree_graph){
+//
+//
+//     for (dng::vertex_t w = 12; w > 0; --w) {
+//         dng::vertex_t v = w - 1;
+//
+//        auto rng = out_edges(v, pedigree_graph);
+//         for (auto it = rng.first; it != rng.second; ++it) {
+//             dng::edge_t ee = *it;
+//             std::cout << "E: "<< e[ee]<< std::endl;
+//         }
+//    }
+//
+//};
+
+
+void dng::PedigreeV2::EraseRemovedLibraries(dng::ReadGroups &rgs, std::vector<size_t> &node_ids) {
+
+    std::size_t num_libraries = rgs.libraries().size();
+    std::vector<std::string> bad_libraries;
+    bad_libraries.reserve(num_libraries);
+    auto it = rgs.libraries().begin();
+    for (size_t u = first_library_; u < node_ids.size(); ++u, ++it) {
+        if (node_ids[u] != -1) {
+            continue;
+        }
+        bad_libraries.push_back(*it);
+    }
+    rgs.EraseLibraries(bad_libraries);
+
+
+}
+
+
+void dng::PedigreeV2::PrintDebugEdges(const std::string &prefix, const dng::Graph &pedigree_graph) {
+#ifdef DEBUG_VERBOSE
+
+//    typedef property_map<Graph, vertex_index_t>::type IndexMap;
+    PropVertexIndex index = get(boost::vertex_index, pedigree_graph);
+
+    boost::graph_traits<Graph>::edge_iterator ei2, ei_end2;
+
+
+    std::cout << prefix << ": V: " << num_vertices(pedigree_graph) << "\tE: " << num_edges(pedigree_graph) << std::endl;
+    for (tie(ei2, ei_end2) = edges(pedigree_graph); ei2 != ei_end2; ++ei2) {
+        std::cout << "(" << index[source(*ei2, pedigree_graph)]
+        << "," << index[target(*ei2, pedigree_graph)] << ") ";
+    }
+    std::cout << " ==END==" << std::endl;
+    std::cout << "Founder, Non_F, Lib, Somatic: " << first_founder_ << "\t" << first_nonfounder_ << "\t" <<
+    first_library_ << "\t" << first_somatic_ << std::endl;
+    std::cout << std::endl;
+#endif
+
+}
+
+
+
+
+void dng::PedigreeV2::CreateFamiliesInfo(dng::Graph &pedigree_graph, family_labels_t &family_labels,
+                                         std::vector<vertex_t> &pivots) {
+//
+//
+//    //LOGIC:: only need 2 variables??
+//
+//    family_labels_t family_labels(num_families);
+//
+//    vector<vertex_t> pivots(num_families, dummy_index);
+//
+//    CreateFamiliesInfo(pedigree_graph, family_labels, pivots);
+
+    auto groups = get(boost::vertex_group, pedigree_graph);
+    auto families = get(boost::edge_family, pedigree_graph);
+
+
+    boost::graph_traits<Graph>::edge_iterator ei, ei_end;
+
+
+    // Calculate the connected components.  This defines independent sections
+    // of the graph.
+    std::size_t num_groups = connected_components(pedigree_graph, groups);
+
+    // Calculate the biconnected components and articulation points.
+    // This defines "nuclear" families and pivot individuals.
+    // Nodes which have no edges will not be part of any family.
+    std::vector<vertex_t> articulation_vertices;
+    std::size_t num_families = biconnected_components(pedigree_graph, families,
+                                                      back_inserter(articulation_vertices)).first;
+
+
+    family_labels = family_labels_t(num_families);
+    pivots = std::vector<vertex_t>(num_families, DUMMY_INDEX);
+
+
+
+
+    // Determine which edges belong to which nuclear families.
+//    typedef vector<vector<graph_traits<Graph>::edge_descriptor>> family_labels_t;
+//    family_labels_t family_labels(num_families);
+    for (tie(ei, ei_end) = edges(pedigree_graph); ei != ei_end; ++ei) {
+        family_labels[families[*ei]].push_back(*ei);
+    }
+
+    // Determine the last family in each group.  All singleton groups will have
+    // a value of -1 since they have no family assignment.
+    //XXX: strictly size_t != -1, is it good to overflow trick here?
+    typedef std::deque<std::size_t> root_families_t;
+    root_families_t root_families(num_groups, -1);
+    for (std::size_t f = 0; f < family_labels.size(); ++f) {
+        // last one wins
+        auto first_edge = family_labels[f][0];
+        auto src_vertex = source(first_edge, pedigree_graph);
+        root_families[groups[src_vertex]] = f;
+
+    }
+
+
+    // Identify the pivot for each family.
+    // The pivot will be the last art. point that has an edge in
+    // the group.  The pivot of the last group doesn't matter.
+    for (auto a : articulation_vertices) {
+        boost::graph_traits<Graph>::out_edge_iterator ei, ei_end;
+        for (tie(ei, ei_end) = out_edges(a, pedigree_graph); ei != ei_end; ++ei) {
+            // Just overwrite existing value so that the last one wins.
+            pivots[families[*ei]] = a;
+        }
+    }
+
+
+    // Root Pivots are special
+    for (auto f : root_families) {
+        if (f == -1) { // skip all singleton groups
+            continue;
+        }
+        pivots[f] = DUMMY_INDEX;
+    }
+
+
+//    std::cout << "\n=======================\n" <<
+//    "num_goups: " << num_groups << "\tnum_fam: " << num_families << std::endl;
+//    for (int j = 0; j < num_vertices(pedigree_graph) ; ++j) {
+//        std::cout << "groups["<< j << "] ->" << groups[j]<< std::endl;
+//    }
+//    for(tie(ei, ei_end) = edges(pedigree_graph); ei != ei_end; ++ei) {
+//        std::cout << "Edge in family: " << *ei << "\t" << families[*ei] << std::endl;
+//    }
+//    std::cout << "articulation_vertices: ";
+//    for (auto a : articulation_vertices) {
+//        std::cout << a << " ";
+//    }
+//    std::cout << ""<< std::endl;
+
+
+
+//    for (int k = 0; k < root_families.size(); ++k) {
+//        std::cout << "root_families: [group= " << k << "] -> " <<  root_families[k] << std::endl;
+//    }
+//
+//
+//    std::cout << "articulation_vertices: ";
+//    for (auto a : articulation_vertices) {
+//        std::cout << a << " ";
+//    }
+//    std::cout << ""<< std::endl;
+
+
+//    {
+//        graph_traits<Graph>::edge_iterator ei, ei_end;
+//        for(tie(ei, ei_end) = edges(pedigree_graph); ei != ei_end; ++ei) {
+//            std::cout <<"E:     "<< *ei << std::endl;
+//        }
+//    }
+//    {
+//        for(auto a : articulation_vertices) {
+//            graph_traits<Graph>::in_edge_iterator ei, ei_end;
+//            for (tie(ei, ei_end) = in_edges(a, pedigree_graph); ei != ei_end; ++ei) {
+//                std::cout << "In_E:  " << *ei << "\t" << a<< std::endl;
+//            }
+//        }
+//    }
+//    {
+//        for(auto a : articulation_vertices) {
+//            graph_traits<Graph>::out_edge_iterator ei, ei_end;
+//            for (tie(ei, ei_end) = out_edges(a, pedigree_graph); ei != ei_end; ++ei) {
+//                std::cout << "Out_E: " << * ei << "\t" << a<< std::endl;
+//            }
+//        }
+//    }
+//    for (int m = 0; m < pivots.size(); ++m) {
+//        std::cout << "pivots: [family= " << m << "] -> " << pivots[m] << std::endl;
+//    }
+
+
+#ifdef DEBUG_VERBOSE
+
+    for (int l = 0; l < family_labels.size(); ++l) {
+        std::cout << "Families : " << l << "\tPivots: " << pivots[l] << "\t";
+        for (auto f : family_labels[l]) {
+            std::cout << f << " ";
+        }
+        std::cout << std::endl;
+    }
+
+#endif
+}
+
+
+void dng::PedigreeV2::CreatePeelingOps(dng::Graph &pedigree_graph, const std::vector<size_t> &node_ids,
+                                       family_labels_t &family_labels, std::vector<vertex_t> &pivots) {
+
+    auto edge_types = get(boost::edge_type, pedigree_graph);
+    auto lengths = get(boost::edge_length, pedigree_graph);
+
+
+    // Resize the information in the pedigree
+    transitions_.resize(num_nodes_);
+    for (std::size_t i = first_founder_; i < first_nonfounder_; ++i) {
+        transitions_[i] = {TransitionType::Founder, static_cast<size_t>(-1), static_cast<size_t>(-1), 0, 0};
+    }
+
+//    index = get(vertex_index, pedigree_graph);
+    // Detect Family Structure and pivot positions
+    for (std::size_t k = 0; k < family_labels.size(); ++k) {
+
+        auto &family_edges = family_labels[k];
+#ifdef DEBUG_VERBOSE
+        std::cout << "\nStart family: " << k << std::endl;
+        std::cout << "edges: ";
+        for (auto a : family_edges) {
+            std::cout << a << " ";
+        }std::cout << "" << std::endl;
+#endif
+        // Sort edges based on type and target
+        boost::sort(family_edges, [&](edge_t x, edge_t y) -> bool {
+            return (edge_types(x) < edge_types(y)) && (target(x, pedigree_graph) < target(y, pedigree_graph));
+        });
+#ifdef DEBUG_VERBOSE
+
+        std::cout << "Sorted edges: ";
+        for (auto a : family_edges) {
+            std::cout << a << " ";
+        }std::cout << "" << std::endl;
+#endif
+        // Find the range of the parent types
+        auto pos = boost::find_if(family_edges, [&](edge_t x) -> bool {
+            return (edge_types(x) != EdgeType::Spousal);
+        });
+        size_t num_parent_edges = distance(family_edges.begin(), pos);
+#ifdef DEBUG_VERBOSE
+
+        std::cout << "family_edge.size(): " << family_edges.size() <<
+            "\tnum_parent_E: " << num_parent_edges << "\t" <<
+            "\tpos!=(EdgeType::Spousal): " << *pos <<
+            "\tpivot_V: " << pivots[k] << std::endl;
+#endif
+        // Check to see what type of graph we have
+        if (num_parent_edges == 0) {
+            // If we do not have a parent-child single branch,
+            // we can't construct the pedigree.
+            // TODO: Write Error message
+            if (family_edges.size() != 1) {
+//                return false;
+                throw std::runtime_error("Unable to construct peeler for pedigree;  "
+                                                 "do not have a parent-child single branch");
+
+            }
+            // Create a mitotic peeling operation.
+            size_t parent = node_ids[source(*pos, pedigree_graph)];
+            size_t child = node_ids[target(*pos, pedigree_graph)];
+
+            TransitionType tt = (edge_types(*pos) == EdgeType::Library) ?
+                                TransitionType::Library : TransitionType::Somatic;
+            transitions_[child] = {tt, parent, static_cast<size_t>(-1), lengths[*pos], 0};
+            family_members_.push_back({parent, child});
+#ifdef DEBUG_VERBOSE
+
+            std::cout << "=numParentEdge==0: parent " << parent << "\tChild " << child << std::endl;
+            std::cout << "===pivots[k]: " << pivots[k] <<
+                "\t\tnode_id:" << node_ids[pivots[k]] << std::endl;
+#endif
+            if (node_ids[pivots[k]] == child) {
+                peeling_ops_.push_back(peel::op::DOWN);
+//                std::cout << "=====ADD OP: down" << std::endl;
+            } else {
+                peeling_ops_.push_back(peel::op::UP);
+//                std::cout << "=====ADD OP: up" << std::endl;
+                if (pivots[k] == DUMMY_INDEX) {
+                    roots_.push_back(parent);
+                }
+            }
+
+        } else if (num_parent_edges == 1) {
+            // If this family contains no children, skip it
+            if (pos == family_edges.end()) {
+                continue;
+            }
+            // We have a nuclear family with 1 or more children
+            size_t dad = node_ids[source(family_edges.front(), pedigree_graph)];
+            size_t mom = node_ids[target(family_edges.front(), pedigree_graph)];
+
+            family_members_.push_back({dad, mom});
+            auto &family_members = family_members_.back();
+#ifdef DEBUG_VERBOSE
+
+            std::cout << "==numParentEdge==1: dad: " << dad << "\tmom: " << mom << std::endl;
+#endif
+            while (pos != family_edges.end()) {
+                vertex_t child = node_ids[target(*pos, pedigree_graph)];
+                transitions_[child] = {TransitionType::Germline, dad, mom,
+                                       lengths[*pos], lengths[*(pos + 1)]
+                };
+                family_members.push_back(child); // Child
+#ifdef DEBUG_VERBOSE
+
+                std::cout << "==Add child to family: " << child << std::endl;
+#endif
+                // child edges come in pairs
+                ++pos;
+                assert(node_ids[target(*pos, pedigree_graph)] == child);
+                ++pos;
+            }
+            if (node_ids[pivots[k]] == node_ids[DUMMY_INDEX]) {
+                // A family without a pivot is a root family
+                peeling_ops_.push_back(peel::op::TOFATHER);
+                roots_.push_back(family_members[0]);
+#ifdef DEBUG_VERBOSE
+                std::cout << "=====ADD OP: toFather Root" << std::endl;
+#endif
+            } else {
+                auto pivot_pos = boost::range::find(family_members, node_ids[pivots[k]]);
+                size_t p = distance(family_members.begin(), pivot_pos);
+#ifdef DEBUG_VERBOSE
+
+                std::cout << "===pivot_pos: " << *pivot_pos << "," << node_ids[pivots[k]] <<
+                    "\tdistance_pivot_to_family_member_begin(): " << p << std::endl;
+#endif
+                if (p == 0) {
+                    peeling_ops_.push_back(peel::op::TOFATHER);
+//                    std::cout << "=====ADD OP: toFather" << std::endl;
+                } else if (p == 1) {
+                    peeling_ops_.push_back(peel::op::TOMOTHER);
+//                    std::cout << "=====ADD OP: toMother" << std::endl;
+                } else if (p == 2) {
+                    peeling_ops_.push_back(peel::op::TOCHILD);
+//                    std::cout << "=====ADD OP: toChild" << std::endl;
+                } else {
+                    peeling_ops_.push_back(peel::op::TOCHILD);
+//                    std::cout << "=====ADD OP: toChild swap" << std::endl;
+                    boost::swap(family_members[p], family_members[2]);
+                }
+            }
+
+        } else {
+            throw std::runtime_error("Unable to construct peeler for pedigree; Not a zero-loop pedigree");
+            // TODO: write error message
+        }
+    }
+
+
+}
+
+
+
+
+//
+//bool dng::PedigreeV2::Equal(dng::Pedigree &other_ped) {
+//
+//    AssertEqual(num_nodes_, other_ped.num_nodes());
+//    AssertEqual(first_founder_, other_ped.first_founder_);
+//    AssertEqual(first_nonfounder_, other_ped.first_nonfounder_);
+//    AssertEqual(first_somatic_, other_ped.first_somatic_);
+//    AssertEqual(first_library_, other_ped.first_library_);
+//
+//    auto other_labels = other_ped.labels();
+//    AssertVectorEqual(labels_, other_labels);
+//
+//    //TODO: How to iterate through struct? without create another function in struct?
+//    auto other_transitions = other_ped.transitions();
+//    for (int j = 0; j < transitions_.size(); ++j) {
+//        assert(transitions_[j].type == other_transitions[j].type);
+//        assert(transitions_[j].parent1 == other_transitions[j].parent1);
+//        assert(transitions_[j].parent2 == other_transitions[j].parent2);
+//        assert(transitions_[j].length1 == other_transitions[j].length1);
+//        assert(transitions_[j].length2 == other_transitions[j].length2);
+//    }
+//
+//    auto other_roots = other_ped.roots_;
+//    AssertVectorEqual(roots_, other_roots);
+//
+//    auto other_peeling_ops = other_ped.peeling_ops_;
+//    AssertVectorEqual(peeling_ops_, other_peeling_ops);
+//
+//    auto other_peeling_function_ops = other_ped.peeling_functions_ops_;
+//    AssertVectorEqual(peeling_functions_ops_, other_peeling_function_ops);
+//
+//
+//    auto other_peeling_functions = other_ped.peeling_functions_;
+//    for (int j = 0; j < peeling_functions_.size() - 1; ++j) {
+//        int op_index = peeling_functions_ops_[j];
+//
+//        assert(dng::peel::functions[op_index] == other_peeling_functions[j]);
+//        //Check against expected dng::peel::functions
+//        assert(peeling_functions_[j] == other_peeling_functions[j]); //Check against others
+//        //
+//
+//    }
+//
+//    auto other_peeling_reverse_functions = other_ped.peeling_reverse_functions_;
+//    for (int j = 0; j < peeling_reverse_functions_.size() - 1; ++j) {
+//        int op_index = peeling_functions_ops_[j];
+//        assert(dng::peel::reverse_functions[op_index] ==
+//               other_peeling_reverse_functions[j]); //Check against expected dng::peel::functions
+//        assert(peeling_reverse_functions_[j] == other_peeling_reverse_functions[j]); //Check against others
+//
+//    }
+//
+//
+//    auto other_family_members_ = other_ped.family_members_;
+//    AssertEqual(family_members_.size(), other_family_members_.size());
+//    for (int k = 0; k < family_members_.size(); ++k) {
+//        AssertVectorEqual(family_members_[k], other_family_members_[k]);
+//    }
+//
+//    return true;
+//
+//
+//}

--- a/src/lib/pedigree_v2.cc
+++ b/src/lib/pedigree_v2.cc
@@ -846,16 +846,16 @@ void dng::PedigreeV2::CreatePeelingOps(dng::Graph &pedigree_graph, const std::ve
 
 
 //
-//bool dng::PedigreeV2::Equal(dng::Pedigree &other_ped) {
+//bool dng::PedigreeV2::equal(dng::Pedigree &other_ped) {
 //
-//    AssertEqual(num_nodes_, other_ped.num_nodes());
-//    AssertEqual(first_founder_, other_ped.first_founder_);
-//    AssertEqual(first_nonfounder_, other_ped.first_nonfounder_);
-//    AssertEqual(first_somatic_, other_ped.first_somatic_);
-//    AssertEqual(first_library_, other_ped.first_library_);
+//    assert_equal(num_nodes_, other_ped.num_nodes());
+//    assert_equal(first_founder_, other_ped.first_founder_);
+//    assert_equal(first_nonfounder_, other_ped.first_nonfounder_);
+//    assert_equal(first_somatic_, other_ped.first_somatic_);
+//    assert_equal(first_library_, other_ped.first_library_);
 //
 //    auto other_labels = other_ped.labels();
-//    AssertVectorEqual(labels_, other_labels);
+//    assert_equal_vector(labels_, other_labels);
 //
 //    //TODO: How to iterate through struct? without create another function in struct?
 //    auto other_transitions = other_ped.transitions();
@@ -868,13 +868,13 @@ void dng::PedigreeV2::CreatePeelingOps(dng::Graph &pedigree_graph, const std::ve
 //    }
 //
 //    auto other_roots = other_ped.roots_;
-//    AssertVectorEqual(roots_, other_roots);
+//    assert_equal_vector(roots_, other_roots);
 //
 //    auto other_peeling_ops = other_ped.peeling_ops_;
-//    AssertVectorEqual(peeling_ops_, other_peeling_ops);
+//    assert_equal_vector(peeling_ops_, other_peeling_ops);
 //
 //    auto other_peeling_function_ops = other_ped.peeling_functions_ops_;
-//    AssertVectorEqual(peeling_functions_ops_, other_peeling_function_ops);
+//    assert_equal_vector(peeling_functions_ops_, other_peeling_function_ops);
 //
 //
 //    auto other_peeling_functions = other_ped.peeling_functions_;
@@ -899,9 +899,9 @@ void dng::PedigreeV2::CreatePeelingOps(dng::Graph &pedigree_graph, const std::ve
 //
 //
 //    auto other_family_members_ = other_ped.family_members_;
-//    AssertEqual(family_members_.size(), other_family_members_.size());
+//    assert_equal(family_members_.size(), other_family_members_.size());
 //    for (int k = 0; k < family_members_.size(); ++k) {
-//        AssertVectorEqual(family_members_[k], other_family_members_[k]);
+//        assert_equal_vector(family_members_[k], other_family_members_[k]);
 //    }
 //
 //    return true;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -52,22 +52,27 @@ SET_TESTS_PROPERTIES(build_gitkeep PROPERTIES
 
 ################################################################################
 # Compile unit tests
-include_directories(../src/include)
+include_directories(${CMAKE_SOURCE_DIR}/src/include)
+include_directories(${CMAKE_SOURCE_DIR}/src)
+include_directories(./src/)
+
+SET(UNITTEST_LIBRARIES Threads::Threads
+        Boost::PROGRAM_OPTIONS
+        Boost::FILESYSTEM
+        Boost::SYSTEM
+        Boost::UNIT_TEST_FRAMEWORK
+        EIGEN3::EIGEN3
+        HTSLIB::HTSLIB
+        )
+
 
 # Make a test for each unit test file located in test/ dir
 file(GLOB_RECURSE TESTS test_*[cc|cpp])
 foreach(test ${TESTS})
   get_filename_component(testName ${test} NAME_WE)
   add_executable(${testName} EXCLUDE_FROM_ALL ${test})
-  target_link_libraries(${testName}
-    Threads::Threads
-    Boost::PROGRAM_OPTIONS
-    Boost::FILESYSTEM
-    Boost::SYSTEM
-    Boost::UNIT_TEST_FRAMEWORK
-    EIGEN3::EIGEN3
-    HTSLIB::HTSLIB
-  )
+  target_link_libraries(${testName} ${UNITTEST_LIBRARIES})
+
   add_test(${testName}_build "${CMAKE_COMMAND}" --build ${CMAKE_BINARY_DIR} --target ${testName})
   add_test(${testName}_run ${testName})
   set_tests_properties(${testName}_run PROPERTIES DEPENDS ${testName}_build)
@@ -76,34 +81,62 @@ endforeach(test)
 ################################################################################
 
 
-
 ################################################################################
-# temp Compile unit tests with *.cc
-# TODO: Use a different filename pattern for now (test2_* instead of test_*).
-# TODO: How to add min *.cc files instead of all *.cc later?
-include_directories(./)
+## TODO: How to build something like "make timetrail" and compile all time measuring files
+IF(DEVEL_MODE)
+  ADD_DEFINITIONS(-DDNG_DEVEL)
+ENDIF()
 
-file(GLOB_RECURSE TESTS2 "test2_*[cc|cpp]")
+file(GLOB_RECURSE TESTS2 "testt_time*[cc|cpp]")
 foreach(test ${TESTS2})
   get_filename_component(testName ${test} NAME_WE)
   add_executable(${testName} EXCLUDE_FROM_ALL ${test}
           ${CMAKE_SOURCE_DIR}/src/lib/peeling.cc
-          ##            ../src/lib/likelihood.cc ../src/lib/newick.cc ../src/lib/pedigree.cc
-          ##            ../src/lib/mutation.cc ../src/lib/stats.cc
+          ${CMAKE_SOURCE_DIR}/src/lib/likelihood.cc
+          ${CMAKE_SOURCE_DIR}/src/lib/newick.cc
+          ${CMAKE_SOURCE_DIR}/src/lib/pedigree.cc
+          ${CMAKE_SOURCE_DIR}/src/lib/mutation.cc
+          ${CMAKE_SOURCE_DIR}/src/lib/stats.cc
           )
-  target_link_libraries(${testName}
-          Threads::Threads
-          Boost::PROGRAM_OPTIONS
-          Boost::FILESYSTEM
-          Boost::SYSTEM
-          Boost::UNIT_TEST_FRAMEWORK
-          EIGEN3::EIGEN3
-          HTSLIB::HTSLIB
+
+  target_link_libraries(${testName} ${UNITTEST_LIBRARIES})
+
+  IF(DEVEL_MODE)
+    TARGET_LINK_LIBRARIES(${testName} Boost::TIMER)
+  ENDIF()
+#  add_test(${testName}_build "${CMAKE_COMMAND}" --build ${CMAKE_BINARY_DIR} --target ${testName})
+#  add_test(${testName}_run ${testName})
+#  set_tests_properties(${testName}_run PROPERTIES DEPENDS ${testName}_build)
+endforeach(test)
+
+
+
+# Temp Compile unit tests with *.cc
+# TODO: Use a different filename pattern for now (test2_* instead of test_*).
+# TODO: How to add min *.cc files instead of all *.cc later?
+
+add_definitions(-DTESTDATA_DIR=\"${TESTDATA_DIR}\")
+file(GLOB_RECURSE TESTS2 "test2_*[cc|cpp]")
+foreach (test ${TESTS2})
+  get_filename_component(testName ${test} NAME_WE)
+  add_executable(${testName} EXCLUDE_FROM_ALL ${test}
+          ${CMAKE_SOURCE_DIR}/src/lib/peeling.cc
+          ${CMAKE_SOURCE_DIR}/src/lib/likelihood.cc
+          ${CMAKE_SOURCE_DIR}/src/lib/newick.cc
+          ${CMAKE_SOURCE_DIR}/src/lib/pedigree.cc
+          ${CMAKE_SOURCE_DIR}/src/lib/mutation.cc
+          ${CMAKE_SOURCE_DIR}/src/lib/stats.cc
+
+          ${CMAKE_SOURCE_DIR}/src/lib/pedigree_v2.cc
+#          ${CMAKE_SOURCE_DIR}/src/lib/find_mutation.cc
+#          ${CMAKE_SOURCE_DIR}/src/lib/mutation_stats.cc
           )
+  target_link_libraries(${testName} ${UNITTEST_LIBRARIES})
+
   add_test(${testName}_build "${CMAKE_COMMAND}" --build ${CMAKE_BINARY_DIR} --target ${testName})
   add_test(${testName}_run ${testName})
   set_tests_properties(${testName}_run PROPERTIES DEPENDS ${testName}_build)
-endforeach(test)
+endforeach (test)
 
 ################################################################################
 

--- a/test/src/boost_test_helper.h
+++ b/test/src/boost_test_helper.h
@@ -1,0 +1,96 @@
+//
+// Created by steven on 1/15/16.
+//
+// Replace some with with BOOST later
+//
+
+#ifndef DENOVOGEAR_BOOST_TEST_HELPER_H
+#define DENOVOGEAR_BOOST_TEST_HELPER_H
+
+#include <boost/test/test_tools.hpp>
+#include <boost/test/unit_test.hpp>
+
+//TODO: Where should this file go?
+//FIXME: too many global
+const double ABS_TEST_THRESHOLD = 1e-10;
+const double BOOST_CLOSE_THRESHOLD = 1e-3;//
+const double BOOST_SMALL_THRESHOLD = sqrt(std::numeric_limits<double>::epsilon());
+//TODO: What is a good cut? 1e-8?// sqrt(std::numeric_limits<double>::epsilon());
+
+
+template<typename V, typename V2>
+void boost_check_equal_vector(V &expected, V2 &result) {
+
+    BOOST_CHECK_EQUAL(expected.size(), result.size());
+    for (int i = 0; i < expected.size(); ++i) {
+        BOOST_CHECK(expected[i] == result[i]);
+    }
+}
+
+template<typename V, typename V2>
+void boost_check_close_vector(V &expected, V2 &result) {
+
+    BOOST_CHECK_EQUAL(expected.size(), result.size());
+    for (int i = 0; i < expected.size(); ++i) {
+        if(expected[i] == 0){
+            BOOST_CHECK_EQUAL(0, result[i]);
+        }
+        else {
+            BOOST_CHECK_CLOSE(expected[i], result[i], BOOST_CLOSE_THRESHOLD);
+        }
+    }
+}
+
+template<typename V, typename V2>
+void boost_check_close_vector(V &&expected, V2 &result) {
+
+    BOOST_CHECK_EQUAL(expected.size(), result.size());
+    for (int i = 0; i < expected.size(); ++i) {
+        if(expected[i] == 0){
+            BOOST_CHECK_EQUAL(0, result[i]);
+        }
+        else {
+            BOOST_CHECK_CLOSE(expected[i], result[i], BOOST_CLOSE_THRESHOLD);
+        }
+    }
+}
+
+template<typename V, typename V2>
+void boost_check_close_vector(V &expected, V2 &result, int expected_size) {
+    
+    BOOST_CHECK_EQUAL(expected_size, expected.size());
+    boost_check_close_vector(expected, result);
+}
+
+
+
+template<typename M>
+void boost_check_matrix(M &expected, M &result) {
+    BOOST_CHECK_EQUAL(expected.rows(), result.rows());
+    BOOST_CHECK_EQUAL(expected.cols(), result.cols());
+
+    for (int i = 0; i < expected.rows(); ++i) {
+        for (int j = 0; j < expected.cols(); ++j) {
+            if(expected(i,j) == 0 ){
+                BOOST_CHECK_EQUAL(0, result(i,j));
+            }
+            else {
+                BOOST_CHECK_CLOSE(expected(i, j), result(i, j), BOOST_CLOSE_THRESHOLD);
+            }
+        }
+    }
+}
+
+
+template<typename M>
+void boost_check_matrix(M &expected, M &result, int expected_rows, int expected_cols) {
+    BOOST_CHECK_EQUAL(expected_rows, expected.rows());
+    BOOST_CHECK_EQUAL(expected_cols, expected.cols());
+
+    boost_check_matrix(expected, result);
+}
+
+
+
+
+#endif //DENOVOGEAR_BOOST_TEST_HELPER_H

--- a/test/src/fixture/fixture_random_family.h
+++ b/test/src/fixture/fixture_random_family.h
@@ -1,0 +1,147 @@
+//
+// Created by steven on 1/24/16.
+//
+#pragma once
+#ifndef DENOVOGEAR_FIXTURE_RANDOM_FAMILY_H
+#define DENOVOGEAR_FIXTURE_RANDOM_FAMILY_H
+
+#include <dng/peeling.h>
+
+namespace utf = boost::unit_test;
+
+
+struct RandomFamily {
+    const int CHILD_OFFSET = 2;
+    std::string fixture;
+
+    std::mt19937 random_gen_mt {1}; //seed = 1
+
+
+    dng::peel::family_members_t family;
+    std::vector<dng::TransitionMatrix> trans_matrix;
+    std::vector<dng::GenotypeArray> upper_array;
+    std::vector<dng::GenotypeArray> lower_array;
+
+    int num_child;
+    int total_family_size;
+    std::uniform_int_distribution<> rand_unif;
+
+    RandomFamily(std::string s = "RandomFamily") : fixture(s) {
+        BOOST_TEST_MESSAGE("set up fixture:  " << fixture);
+        rand_unif = std::uniform_int_distribution<>(1,10);
+        init_family();
+    }
+
+    void init_family(){
+
+        int num_child = rand_unif(random_gen_mt);
+        total_family_size = num_child + CHILD_OFFSET;
+        family.clear();
+        trans_matrix.resize(total_family_size);
+        upper_array.resize(total_family_size);
+        lower_array.resize(total_family_size);
+
+        for (int k = 0; k < total_family_size; ++k) {
+            family.push_back(k);
+            lower_array[k] = dng::GenotypeArray::Random();
+            if (k < CHILD_OFFSET) {
+                trans_matrix[k] = dng::TransitionMatrix::Random(10, 10);
+                upper_array[k] = dng::GenotypeArray::Random();
+            }
+            else {
+                trans_matrix[k] = dng::TransitionMatrix::Random(100, 10);
+            }
+
+        }
+    }
+
+    void init_family_parent_child_only(){
+
+        total_family_size = 2;
+
+        family.clear();
+        trans_matrix.resize(total_family_size);
+        upper_array.resize(total_family_size);
+        lower_array.resize(total_family_size);
+
+        for (int k = 0; k < total_family_size; ++k) {
+            family.push_back(k);
+            trans_matrix[k] = dng::TransitionMatrix::Random(10, 10);
+            lower_array[k] = dng::GenotypeArray::Random();
+//            upper_array[k] = GenotypeArray::Random();
+
+        }
+    }
+
+    ~RandomFamily() {
+        BOOST_TEST_MESSAGE("tear down fixture: " << fixture);
+    }
+};
+
+void copy_family_to_workspace(dng::peel::workspace_t &workspace, dng::TransitionVector &full_matrix,
+                              int total_family_size, const std::vector<dng::GenotypeArray> &lower,
+                              const std::vector<dng::GenotypeArray> &upper,
+                              const std::vector<dng::TransitionMatrix> &trans_mat) {
+    workspace.Resize(total_family_size);
+    full_matrix.resize(total_family_size);
+    for (int l = 0; l < total_family_size; ++l) {
+        workspace.lower[l] = lower[l];
+        workspace.upper[l] = upper[l];
+        full_matrix[l] = trans_mat[l];
+    }
+}
+
+
+struct RandomWorkspace {
+
+
+    std::string fixture;
+
+    dng::peel::workspace_t workspace;
+    dng::TransitionVector full_matrix;
+
+    RandomWorkspace(std::string s = "") : fixture(s) {
+        BOOST_TEST_MESSAGE("set up fixture: RandomWorkspace " << s);
+
+    }
+
+    void init_workspace(){
+        RandomFamily family;
+
+        family.init_family();
+        copy_family_to_workspace(workspace, full_matrix,
+                                 family.total_family_size, family.lower_array, family.upper_array,
+                                 family.trans_matrix);
+
+    }
+
+
+    ~RandomWorkspace() {
+        BOOST_TEST_MESSAGE("tear down fixture: RandomWorkspace " << fixture);
+    }
+//        int num_child = rand_unif(random_gen_mt);
+//        total_family_size = num_child + CHILD_OFFSET;
+//
+//        family.clear();
+//        trans_matrix.resize(total_family_size);
+//        upper_array.resize(total_family_size);
+//        lower_array.resize(total_family_size);
+//
+//        for (int k = 0; k < total_family_size; ++k) {
+//            family.push_back(k);
+//            lower_array[k] = dng::GenotypeArray::Random();
+//            if (k < CHILD_OFFSET) {
+//                trans_matrix[k] = dng::TransitionMatrix::Random(10, 10);
+//                upper_array[k] = dng::GenotypeArray::Random();
+//            }
+//            else {
+//                trans_matrix[k] = dng::TransitionMatrix::Random(100, 10);
+//
+//            }
+//
+//    void init_family(){
+};
+
+
+
+#endif //DENOVOGEAR_FIXTURE_RANDOM_FAMILY_H

--- a/test/src/fixture/fixture_read_trio_from_file.h
+++ b/test/src/fixture/fixture_read_trio_from_file.h
@@ -1,0 +1,98 @@
+//
+// Created by steven on 2/12/16.
+//
+
+#pragma once
+#ifndef DENOVOGEAR_FIXTURE_READ_TRIO_FROM_FILE_H
+#define DENOVOGEAR_FIXTURE_READ_TRIO_FROM_FILE_H
+
+#include <fstream>
+
+#include <dng/task/call.h>
+#include <utils/boost_utils.h>
+//#include <helpers/find_mutation_helper.h>
+#include <dng/hts/bcf.h>
+
+using namespace dng;
+namespace utf = boost::unit_test;
+
+struct ReadTrioFromFile {
+
+    std::string fixture;
+
+    dng::io::Pedigree ped;
+    dng::ReadGroups rgs;
+
+    typedef dng::task::Call task_type;
+    struct arg_t : public task_type::argument_type {
+        bool help;
+        bool version;
+        std::string arg_file;
+
+        std::string run_name;
+        std::string run_path;
+    } arg;
+
+    ReadTrioFromFile(std::string s = "ReadTrioFromFile") : fixture(s) {
+        BOOST_TEST_MESSAGE("set up fixture: " << fixture);
+
+        po::options_description ext_desc_, int_desc_;
+        po::positional_options_description pos_desc_;
+        po::variables_map vm_;
+
+        int argc=4;
+        char *argv[argc];
+        argv[0] = (char*) "test";
+        argv[1] = (char*) "-p";
+
+        std::string ped_filename (TESTDATA_DIR);
+        ped_filename.append("/sample_5_3/ceu.ped");
+        argv[2] = (char*) ped_filename.data();
+
+        std::string vcf_filename = TESTDATA_DIR;
+        vcf_filename.append("/sample_5_3/test1.vcf");
+        argv[3] = (char*) vcf_filename.data();
+
+        add_app_args(ext_desc_, static_cast<typename task_type::argument_type &>(arg));
+        int_desc_.add_options()
+                ("input", po::value< std::vector<std::string> >(&arg.input), "input files")
+                ;
+        int_desc_.add(ext_desc_);
+        pos_desc_.add("input", -1);
+        po::store(po::command_line_parser(argc, argv)
+                          .options(int_desc_).positional(pos_desc_).run(), vm_);
+        po::notify(vm_);
+
+        // Parse pedigree from file
+
+        std::ifstream ped_file(arg.ped);
+        ped.Parse(utils::istreambuf_range(ped_file));
+
+
+        std::vector<hts::File> indata;
+        std::vector<hts::bcf::File> bcfdata;
+        for (auto &&str : arg.input) {
+            indata.emplace_back(str.c_str(), "r");
+            if (indata.back().is_open()) {
+                continue;
+            }
+            throw std::runtime_error("unable to open input file '" + str + "'.");
+        }
+        bcfdata.emplace_back(std::move(indata[0]));
+        rgs.ParseSamples(bcfdata[0]);
+
+
+
+    }
+
+
+
+    ~ReadTrioFromFile() {
+        BOOST_TEST_MESSAGE("tear down fixture: " << fixture);
+    }
+
+
+};
+
+
+#endif //DENOVOGEAR_FIXTURE_READ_TRIO_FROM_FILE_H

--- a/test/src/fixture/fixture_trio_workspace.h
+++ b/test/src/fixture/fixture_trio_workspace.h
@@ -1,0 +1,89 @@
+//
+// Created by steven on 2/23/16.
+//
+
+#pragma once
+#ifndef DENOVOGEAR_FIXTURE_TRIO_WORKSPACE_H
+#define DENOVOGEAR_FIXTURE_TRIO_WORKSPACE_H
+
+#include <helpers/find_mutation_helper.h>
+#include <fixture/fixture_read_trio_from_file.h>
+
+struct TrioWorkspace : public  ReadTrioFromFile {
+
+    double min_prob;
+
+    dng::Pedigree pedigree;
+    dng::peel::workspace_t workspace;
+
+    int ref_index = 2;
+    std::vector<depth_t> read_depths{3};
+
+    FindMutations::params_t test_param_1 {0, {0,0,0,0}, 0,
+                                          std::string("0,0,0,0"),
+                                          std::string("0,0,0,0") };
+
+    TrioWorkspace(std::string s = "TrioWorkspace") : ReadTrioFromFile(s) {
+        BOOST_TEST_MESSAGE("set up fixture: " << fixture);
+
+
+        pedigree.Construct(ped, rgs, arg.mu, arg.mu_somatic, arg.mu_library);
+
+        std::array<double, 4> freqs;
+        auto f = util::parse_double_list(arg.nuc_freqs, ',', 4);
+        std::copy(f.first.begin(), f.first.end(), &freqs[0]);
+
+        test_param_1 = FindMutations::params_t {arg.theta, freqs, arg.ref_weight, arg.gamma[0], arg.gamma[1]};
+
+
+        int min_qual = arg.min_basequal;
+        min_prob = arg.min_prob;
+
+        ref_index = 2;
+        uint16_t cc[3][4] = {{0, 1, 25, 29},
+                             {0, 0, 57, 0},
+                             {0, 0, 76, 1}};
+        for (int j = 0; j < 3; ++j) {
+            std::copy(cc[j], cc[j] + 4, read_depths[j].counts);
+        }
+        setup_workspace(ref_index, read_depths);
+
+    }
+
+    double setup_workspace(int ref_index, std::vector<depth_t> &read_depths ){
+
+        workspace.Resize(5);
+        workspace.founder_nodes = std::make_pair(0, 2);
+        workspace.germline_nodes = std::make_pair(0, 2);
+        workspace.somatic_nodes = std::make_pair(2, 2);
+        workspace.library_nodes = std::make_pair(2, 5);
+
+        std::array<double, 4> prior {};
+        prior.fill(0);
+        prior[ref_index] = test_param_1.ref_weight;
+        auto genotype_prior_prior = population_prior(test_param_1.theta, test_param_1.nuc_freq, prior);
+        workspace.SetFounders(genotype_prior_prior);
+
+        std::vector<std::string> expect_gamma{"0.98, 0.0005, 0.0005, 1.04",
+                                              "0.02, 0.075,  0.005,  1.18"};
+        dng::genotype::DirichletMultinomialMixture genotype_likelihood_{
+                dng::genotype::DirichletMultinomialMixture::params_t {expect_gamma[0]},
+                dng::genotype::DirichletMultinomialMixture::params_t {expect_gamma[1]}  };
+        double scale = 0.0, stemp;
+        for (std::size_t u = 0; u < read_depths.size(); ++u) {
+            std::tie(workspace.lower[2 + u], stemp) =
+                    genotype_likelihood_(read_depths[u], ref_index);
+            scale += stemp;
+        }
+        return scale;
+    }
+
+    ~TrioWorkspace() {
+        BOOST_TEST_MESSAGE("tear down fixture: " << fixture);
+    }
+
+
+};
+
+
+#endif //DENOVOGEAR_FIXTURE_TRIO_WORKSPACE_H

--- a/test/src/lib/test2_pedigree_v2.cc
+++ b/test/src/lib/test2_pedigree_v2.cc
@@ -149,7 +149,7 @@ BOOST_AUTO_TEST_CASE(test_constructor, *utf::fixture(&setup, &teardown)) {
 
 BOOST_AUTO_TEST_CASE(test_pedigree_equal, *utf::fixture(&setup, &teardown)) {
 
-    bool is_equal = pedigree.Equal(pedigree_v2);
+    bool is_equal = pedigree.equal(pedigree_v2);
     BOOST_CHECK(is_equal);
 }
 
@@ -183,7 +183,7 @@ BOOST_AUTO_TEST_CASE(test_constructor_2, *utf::fixture(&setup, &teardown)) {
         BOOST_CHECK_EQUAL(expected_labels[j], labels[j]);
     }
 
-    
+
     auto size_t_negative_one = static_cast<size_t>(-1);
     std::vector<Pedigree::transition_t> expected_transitions = {
             {Pedigree::TransitionType::Founder, size_t_negative_one, size_t_negative_one , 0, 0},
@@ -212,7 +212,7 @@ BOOST_AUTO_TEST_CASE(test_constructor_2, *utf::fixture(&setup, &teardown)) {
 
 BOOST_AUTO_TEST_CASE(test_pedigree_v2, *utf::fixture(&setup, &teardown)) {
 
-    
+
     BOOST_CHECK_EQUAL(5, pedigree_v2.num_nodes());
 
 

--- a/test/src/lib/test2_pedigree_v2.cc
+++ b/test/src/lib/test2_pedigree_v2.cc
@@ -1,0 +1,245 @@
+//
+// Created by steven on 2/9/16.
+//
+
+#define BOOST_TEST_MODULE dng::lib::pedigree
+
+#include <boost/test/unit_test.hpp>
+#include <iostream>
+
+#include <dng/pedigree_v2.h>
+#include <dng/pedigree.h>
+
+#include <fixture/fixture_read_trio_from_file.h>
+#include <boost_test_helper.h>
+
+
+namespace utf = boost::unit_test;
+
+
+struct FixturePedigree : public ReadTrioFromFile{
+
+
+    dng::Pedigree pedigree;
+    dng::PedigreeV2 pedigree_v2;
+
+    FixturePedigree(std::string s = "FixturePedigree") : ReadTrioFromFile(s) {
+        BOOST_TEST_MESSAGE("set up fixture: " << fixture);
+
+        pedigree.Construct(ped, rgs, arg.mu, arg.mu_somatic, arg.mu_library);
+        pedigree_v2.Construct(ped, rgs, arg.mu, arg.mu_somatic, arg.mu_library);
+
+    }
+
+    ~FixturePedigree() {
+        BOOST_TEST_MESSAGE("tear down fixture: " << fixture);
+    }
+
+};
+
+void setup() { BOOST_TEST_MESSAGE("set up fun"); }
+
+void teardown() { BOOST_TEST_MESSAGE("tear down fun"); }
+
+
+
+BOOST_FIXTURE_TEST_SUITE(test_pedigree_suite, FixturePedigree )
+
+/*
+
+0     1
+|     |
+---|---
+|  |  |
+3  2  4
+
+*/
+BOOST_AUTO_TEST_CASE(test_constructor, *utf::fixture(&setup, &teardown)) {
+
+    BOOST_CHECK_EQUAL(5, pedigree.num_nodes() );
+
+    auto workspace = pedigree.CreateWorkspace();
+    BOOST_CHECK_EQUAL(0, workspace.founder_nodes.first);
+    BOOST_CHECK_EQUAL(2, workspace.founder_nodes.second);
+    BOOST_CHECK_EQUAL(0, workspace.germline_nodes.first);
+    BOOST_CHECK_EQUAL(2, workspace.germline_nodes.second);
+    BOOST_CHECK_EQUAL(2, workspace.somatic_nodes.first);
+    BOOST_CHECK_EQUAL(2, workspace.somatic_nodes.second);
+    BOOST_CHECK_EQUAL(2, workspace.library_nodes.first);
+    BOOST_CHECK_EQUAL(5, workspace.library_nodes.second);
+
+
+    auto labels = pedigree.labels();
+
+    const std::vector<std::string> expected_labels = {
+        "GL-1", // founder 1
+        "GL-2", // founder 2
+        "LB-NA12878:Solexa-135852",  // lib 1
+        "LB-NA12891:Solexa-135851",  // lib 2
+        "LB-NA12892:Solexa-135853"   // lib 3
+
+//#CHROM  POS     ID      REF     ALT     QUAL    FILTER  INFO    FORMAT  NA12878:Solexa-135852   NA12891:Solexa-135851   NA12892:Solexa-135853
+    };
+    for (int j = 0; j < 5; ++j) {
+        BOOST_CHECK_EQUAL(expected_labels[j], labels[j]);
+    }
+/* Code relate to labels
+//#define DNG_GL_PREFIX "GL-"
+//#define DNG_SM_PREFIX "SM-" // define also in newick.cc
+//#define DNG_LB_PREFIX "LB-"
+//    // Add the labels for the germline nodes
+//    labels[0] = DNG_GL_PREFIX "unknown";
+//    for (size_t i = 1; i < num_members; ++i) {
+//        labels[i] = DNG_GL_PREFIX + pedigree.name(i);
+//    }
+//    for(auto && a : rgs.libraries()) {
+//        vertex_t v = add_vertex(pedigree_graph);
+//        labels[v] = DNG_LB_PREFIX + a;
+//    }
+//
+//    if(!labels[u].empty()) {
+//        labels_.push_back(labels[u]);
+//    } else {
+//        labels_.push_back(DNG_SM_PREFIX "unnamed_node_" + util::to_pretty(vid));
+//    }
+*/
+
+    auto transitions = pedigree.transitions();
+    auto size_t_negative_one = static_cast<size_t>(-1);
+    std::vector<Pedigree::transition_t> expected_transitions = {
+            {Pedigree::TransitionType::Founder, size_t_negative_one, size_t_negative_one , 0, 0},
+            {Pedigree::TransitionType::Founder, size_t_negative_one, size_t_negative_one , 0, 0},
+            {Pedigree::TransitionType::Germline, 0, 1, arg.mu+arg.mu_somatic+arg.mu_library, arg.mu+arg.mu_somatic+arg.mu_library},
+            {Pedigree::TransitionType::Somatic, 0, size_t_negative_one, arg.mu_somatic + arg.mu_library, 0},
+            {Pedigree::TransitionType::Somatic, 1, size_t_negative_one, arg.mu_somatic + arg.mu_library,0}
+    };
+    //Transition related code
+//    arg.mu, arg.mu_somatic, arg.mu_library);
+//    if(edge_types[*ei] == EdgeType::Meiotic) {
+//        lengths[*ei] *= mu;
+//    } else if(edge_types[*ei] == EdgeType::Mitotic) {
+//        lengths[*ei] *= mu_somatic;
+//    } else if(edge_types[*ei] == EdgeType::Library) {
+//        lengths[*ei] *= mu_library;
+//    }
+//
+//    for(std::size_t i = first_founder_; i < first_nonfounder_; ++i) {
+//        transitions_[i] = {TransitionType::Founder, static_cast<size_t>(-1), static_cast<size_t>(-1), 0, 0};
+//    }
+//    transitions_[child] = {tt, parent, static_cast<size_t>(-1), lengths[*pos], 0};
+//    transitions_[child] = { TransitionType::Germline, dad, mom, lengths[*pos], lengths[*(pos + 1)]  };
+
+    for (int k = 0; k < 5; ++k) {
+        auto expected = expected_transitions[k];
+        auto actual = transitions[k];
+        BOOST_CHECK(expected.type == actual.type);
+        BOOST_CHECK_EQUAL(expected.parent1, actual.parent1);
+        BOOST_CHECK_EQUAL(expected.parent2, actual.parent2);
+        BOOST_CHECK_CLOSE(expected.length1, actual.length1, BOOST_CLOSE_THRESHOLD);
+        BOOST_CHECK_CLOSE(expected.length2, actual.length2, BOOST_CLOSE_THRESHOLD);
+
+    }
+
+
+
+
+}
+
+
+
+BOOST_AUTO_TEST_CASE(test_pedigree_equal, *utf::fixture(&setup, &teardown)) {
+
+    bool is_equal = pedigree.Equal(pedigree_v2);
+    BOOST_CHECK(is_equal);
+}
+
+BOOST_AUTO_TEST_CASE(test_constructor_2, *utf::fixture(&setup, &teardown)) {
+
+    BOOST_CHECK_EQUAL(5, pedigree_v2.num_nodes() );
+
+    auto workspace = pedigree_v2.CreateWorkspace();
+    BOOST_CHECK_EQUAL(0, workspace.founder_nodes.first);
+    BOOST_CHECK_EQUAL(2, workspace.founder_nodes.second);
+    BOOST_CHECK_EQUAL(0, workspace.germline_nodes.first);
+    BOOST_CHECK_EQUAL(2, workspace.germline_nodes.second);
+    BOOST_CHECK_EQUAL(2, workspace.somatic_nodes.first);
+    BOOST_CHECK_EQUAL(2, workspace.somatic_nodes.second);
+    BOOST_CHECK_EQUAL(2, workspace.library_nodes.first);
+    BOOST_CHECK_EQUAL(5, workspace.library_nodes.second);
+
+
+    auto labels = pedigree_v2.labels();
+
+    const std::vector<std::string> expected_labels = {
+            "GL-1", // founder 1
+            "GL-2", // founder 2
+            "LB-NA12878:Solexa-135852",  // lib 1
+            "LB-NA12891:Solexa-135851",  // lib 2
+            "LB-NA12892:Solexa-135853"   // lib 3
+
+//#CHROM  POS     ID      REF     ALT     QUAL    FILTER  INFO    FORMAT  NA12878:Solexa-135852   NA12891:Solexa-135851   NA12892:Solexa-135853
+    };
+    for (int j = 0; j < 5; ++j) {
+        BOOST_CHECK_EQUAL(expected_labels[j], labels[j]);
+    }
+
+    
+    auto size_t_negative_one = static_cast<size_t>(-1);
+    std::vector<Pedigree::transition_t> expected_transitions = {
+            {Pedigree::TransitionType::Founder, size_t_negative_one, size_t_negative_one , 0, 0},
+            {Pedigree::TransitionType::Founder, size_t_negative_one, size_t_negative_one , 0, 0},
+            {Pedigree::TransitionType::Germline, 0, 1, arg.mu+arg.mu_somatic+arg.mu_library, arg.mu+arg.mu_somatic+arg.mu_library},
+            {Pedigree::TransitionType::Somatic, 0, size_t_negative_one, arg.mu_somatic + arg.mu_library, 0},
+            {Pedigree::TransitionType::Somatic, 1, size_t_negative_one, arg.mu_somatic + arg.mu_library,0}
+    };
+
+    auto transitions = pedigree_v2.transitions();
+    for (int k = 0; k < 5; ++k) {
+        auto expected = expected_transitions[k];
+        auto actual = transitions[k];
+        BOOST_CHECK(expected.type == actual.type);
+        BOOST_CHECK_EQUAL(expected.parent1, actual.parent1);
+        BOOST_CHECK_EQUAL(expected.parent2, actual.parent2);
+        BOOST_CHECK_CLOSE(expected.length1, actual.length1, BOOST_CLOSE_THRESHOLD);
+        BOOST_CHECK_CLOSE(expected.length2, actual.length2, BOOST_CLOSE_THRESHOLD);
+
+    }
+
+}
+
+
+
+
+BOOST_AUTO_TEST_CASE(test_pedigree_v2, *utf::fixture(&setup, &teardown)) {
+
+    
+    BOOST_CHECK_EQUAL(5, pedigree_v2.num_nodes());
+
+
+    std::vector<peel::family_members_t> family = pedigree_v2.inspect_family_members();
+    std::vector<peel::family_members_t> expected_family = {
+            {1, 4},
+            {0, 1, 2},
+            {0, 3}
+    };
+
+    for (int f = 0; f < expected_family.size(); ++f) {
+        boost_check_equal_vector(expected_family, family);
+    }
+
+    std::vector<decltype(peel::op::NUM)> ops = pedigree_v2.inspect_peeling_ops();
+    std::vector<decltype(peel::op::NUM)> expected_ops = {peel::op::UP, peel::op::TOFATHER, peel::op::UP};
+    boost_check_equal_vector(expected_ops, ops);
+
+
+
+    std::vector<decltype(peel::op::NUM)> functions_ops = pedigree_v2.inspect_peeling_functions_ops();
+    std::vector<decltype(peel::op::NUM)> expected_functions_ops = {peel::op::UPFAST, peel::op::TOFATHERFAST,
+                                                                  peel::op::UP};
+    boost_check_equal_vector(expected_functions_ops, functions_ops);
+
+
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+

--- a/test/src/lib/test2_peeling.cpp
+++ b/test/src/lib/test2_peeling.cpp
@@ -15,7 +15,7 @@
 
 #include <dng/peeling.h>
 
-#include "boost_test_helper.h"
+#include <boost_test_helper.h>
 
 //#include <boost/test/data/test_case.hpp>
 ////#include <boost/test/data/monomorphic.hpp>
@@ -235,8 +235,8 @@ BOOST_FIXTURE_TEST_SUITE(test_peeling_suite, Fx)
             dng::peel::up_fast(workspace, family, full_matrix);
             GenotypeArray result_fast = workspace.lower[0];
 
-            boost_check_array(expected, result, 10);
-            boost_check_array(expected_fast, result_fast, 10);
+            boost_check_close_vector(expected, result, 10);
+            boost_check_close_vector(expected_fast, result_fast, 10);
 
         }
     }
@@ -292,8 +292,8 @@ BOOST_FIXTURE_TEST_SUITE(test_peeling_suite, Fx)
             GenotypeArray result_fast = workspace.lower[0];
 
 
-            boost_check_array(expected, result, 10);
-            boost_check_array(expected_fast, result_fast, 10);
+            boost_check_close_vector(expected, result, 10);
+            boost_check_close_vector(expected_fast, result_fast, 10);
 
 
 
@@ -348,8 +348,8 @@ BOOST_FIXTURE_TEST_SUITE(test_peeling_suite, Fx)
             dng::peel::to_mother_fast(workspace, family, full_matrix);
             GenotypeArray result_fast = workspace.lower[1];
 
-            boost_check_array(expected, result, 10);
-            boost_check_array(expected_fast, result_fast, 10);
+            boost_check_close_vector(expected, result, 10);
+            boost_check_close_vector(expected_fast, result_fast, 10);
 
 
         }
@@ -414,8 +414,8 @@ BOOST_FIXTURE_TEST_SUITE(test_peeling_suite, Fx)
             GenotypeArray result_fast = workspace.upper[2];
 
 
-            boost_check_array(expected, result, 10);
-            boost_check_array(expected_fast, result_fast, 10);
+            boost_check_close_vector(expected, result, 10);
+            boost_check_close_vector(expected_fast, result_fast, 10);
 
         }
     }


### PR DESCRIPTION
This will be a drop-in replace of the existing class.

The update version will allow more detailed testings, and might be easier to handle different peeling operations if required.
Currently, this class (pedigree_v2) is not used in call.cc yet.

test/CMakeLists.txt might cause conflict later, because not all library are included.
test/src/fixture/ include fixture for boot_test that shared between multiple tests.
