### PR TITLE
Added a unit_test.h header to dng to support our testing framework

### DIFF
--- a/src/include/dng/detail/unit_test.h
+++ b/src/include/dng/detail/unit_test.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2016 Reed A. Cartwright
+ * Authors:  Reed A. Cartwright <reed@cartwrig.ht>
+ *
+ * This file is part of DeNovoGear.
+ *
+ * DeNovoGear is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+#ifndef DNG_DETAIL_UNIT_TEST_H
+#define DNG_DETAIL_UNIT_TEST_H
+
+#ifdef BOOST_TEST_MODULE
+#include <boost/test/unit_test.hpp>
+
+// Declare a class capable of preforming unit tests on public, private, and protected members.
+#define DNG_UNIT_TEST(name) \
+    friend class name
+
+// Declare a nullary function capable of preforming unit tests on public, private, and protected members.
+#define DNG_UNIT_TEST_FUNCTION(name) \
+    friend void name()
+
+#else
+
+#define DNG_UNIT_TEST(name) 
+
+#define DNG_UNIT_TEST_FUNCTION(name) 
+
+#endif
+
+
+#endif // DNG_DETAIL_UNIT_TEST_H

--- a/src/include/dng/peeling.h
+++ b/src/include/dng/peeling.h
@@ -29,6 +29,7 @@
 #include <boost/range/algorithm/fill_n.hpp>
 
 #include <dng/matrix.h>
+#include <dng/detail/unit_test.h>
 
 namespace dng {
 namespace peel {

--- a/src/include/dng/seq.h
+++ b/src/include/dng/seq.h
@@ -22,6 +22,8 @@
 
 #include <htslib/hts.h>
 
+#include <dng/detail/unit_test.h>
+
 namespace dng {
 namespace seq {
 

--- a/src/include/dng/utilities.h
+++ b/src/include/dng/utilities.h
@@ -33,6 +33,8 @@
 
 #include <boost/algorithm/string/predicate.hpp>
 
+#include <dng/detail/unit_test.h>
+
 namespace dng {
 namespace util {
 

--- a/test/src/include/dng/test_seq.cc
+++ b/test/src/include/dng/test_seq.cc
@@ -1,10 +1,9 @@
 #define BOOST_TEST_MODULE "dng::util::seq.h"
 
-#include <boost/test/unit_test.hpp>
 #include <vector>
 #include <string>
 
-#include "dng/seq.h"
+#include <dng/seq.h>
 
 using namespace std;
 

--- a/test/src/include/dng/test_utilities.cc
+++ b/test/src/include/dng/test_utilities.cc
@@ -1,10 +1,9 @@
 #define BOOST_TEST_MODULE "dng::util::utilities.h"
 
-#include <boost/test/unit_test.hpp>
 #include <vector>
 #include <string>
 
-#include "dng/utilities.h"
+#include <dng/utilities.h>
 
 using namespace std;
 

--- a/test/src/lib/test2_peeling.cpp
+++ b/test/src/lib/test2_peeling.cpp
@@ -4,9 +4,6 @@
 
 #define BOOST_TEST_MODULE dng::lib::peeling
 
-#include <boost/test/unit_test.hpp>
-#include <boost/test/floating_point_comparison.hpp>
-
 #include <string>
 #include <cstdlib>
 #include <ctime>


### PR DESCRIPTION
- Created `dng/detail/unit_test.h` to support testing
- This fill will pull in `boost/test/unit_test.hpp` if `BOOST_TEST_MODULE` is defined.
- It will also pull in macros useful for setting up tests.
- Update existing unit tests in accordance.
