### PR TITLE
Improved Support for Regions in Bam Files

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,7 +9,7 @@ INCLUDE_DIRECTORIES(BEFORE "${CMAKE_CURRENT_SOURCE_DIR}/dnm")
 ADD_EXECUTABLE(dng-call
   dng-call.cc
   lib/call.cc lib/likelihood.cc lib/newick.cc lib/pedigree.cc lib/peeling.cc
-  lib/mutation.cc lib/stats.cc
+  lib/mutation.cc lib/stats.cc lib/regions.cc
 )
 
 # Some compilers have incomplete c++11 support provide a list of

--- a/src/include/dng/hts/hts.h
+++ b/src/include/dng/hts/hts.h
@@ -22,7 +22,7 @@
 
 #include <htslib/hts.h>
 #include <memory>
-#include <assert.h>
+#include <cassert>
 
 namespace hts {
 

--- a/src/include/dng/io/utility.h
+++ b/src/include/dng/io/utility.h
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2015-2016 Reed A. Cartwright
+ * Authors:  Reed A. Cartwright <reed@cartwrig.ht>
+ *
+ * This file is part of DeNovoGear.
+ *
+ * DeNovoGear is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+#ifndef DNG_IO_UTILITY_H
+#define DNG_IO_UTILITY_H
+
+#include <string>
+#include <iterator>
+#include <iosfwd>
+#include <istream>
+#include <fstream>
+
+#include <boost/range/iterator_range.hpp>
+
+namespace dng {
+namespace io {
+
+template<typename X, typename T = std::char_traits<X>, typename A = std::allocator<X>>
+inline
+std::basic_string<X,T,A> slurp(std::basic_ifstream<X,T>& input) {
+    std::basic_string<X,T,A> ret;
+    if(!input) {
+        return {};
+    }
+
+    input.seekg(0, std::ios::end);
+    ret.resize(input.tellg());
+    input.seekg(0, std::ios::beg);
+    input.read(&ret[0], ret.size());
+    input.close();
+    return ret;
+}
+
+inline std::string slurp(const char *filename, std::ios_base::openmode mode = std::ios_base::in) {
+    std::ifstream in{filename,mode};
+    return slurp(in);
+}
+
+inline std::string slurp(const std::string& filename, std::ios_base::openmode mode = std::ios_base::in) {
+    std::ifstream in{filename,mode};
+    return slurp(in);
+}
+
+inline std::wstring wslurp(const char *filename, std::ios_base::openmode mode = std::ios_base::in) {
+    std::wifstream in{filename,mode};
+    return slurp(in);
+}
+
+inline std::wstring wslurp(const std::string& filename, std::ios_base::openmode mode = std::ios_base::in) {
+    std::wifstream in{filename,mode};
+    return slurp(in);
+}
+
+// Helper function that mimics boost::istream_range
+template<class Elem, class Traits> inline
+boost::iterator_range<std::istreambuf_iterator<Elem, Traits> >
+istreambuf_range(std::basic_istream<Elem, Traits> &in) {
+    return boost::iterator_range<std::istreambuf_iterator<Elem, Traits>>(
+               std::istreambuf_iterator<Elem, Traits>(in),
+               std::istreambuf_iterator<Elem, Traits>());
+}
+
+bool at_slurp(std::string &ss, std::ios_base::openmode mode = std::ios_base::in) {
+    if(ss.empty() || ss[0] != '@')
+        return false;
+    std::ifstream in{ss.c_str()+1, mode};
+    ss = slurp(in);
+    return true;
+}
+
+}
+} //namespace dng::io
+
+#endif

--- a/src/include/dng/regions.h
+++ b/src/include/dng/regions.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2016 Reed A. Cartwright
+ * Authors:  Reed A. Cartwright <reed@cartwrig.ht>
+ *
+ * This file is part of DeNovoGear.
+ *
+ * DeNovoGear is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+#ifndef DNG_REGIONS_H
+#define DNG_REGIONS_H
+
+#include <utility>
+#include <string>
+
+#include <dng/utility.h>
+#include <dng/hts/bam.h>
+
+#include <dng/detail/unit_test.h>
+
+namespace dng {
+namespace regions {
+
+// 0-based region specification
+struct region_t {
+     region_t(location_t b, location_t e) : beg{b}, end{e} { }
+     region_t(int tid, int b, int e) : beg{utility::make_location(tid,b)}, end{utility::make_location(tid,e)} { }
+     region_t(hts::bam::region_t b) : region_t(b.tid, b.beg, b.end) { }
+     
+     location_t beg;
+     location_t end;
+};
+
+// Parse dng region string into bam regions
+hts::bam::regions_t bam_parse(const std::string &text, const hts::bam::File &file);
+
+namespace detail {
+struct raw_parsed_region_t {
+    std::string target;
+    int beg; // 1-based
+    int end; // 1-based
+};
+
+typedef std::vector<raw_parsed_region_t> raw_parsed_regions_t;
+std::pair<raw_parsed_regions_t,bool> parse_regions(const std::string &text);
+} // namespace dng::regions::detail
+
+} // namespace dng::regions
+} // namespace dng
+
+#endif // DNG_REGIONS_H

--- a/src/include/dng/utility.h
+++ b/src/include/dng/utility.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2015 Reed A. Cartwright
+ * Copyright (c) 2014-2016 Reed A. Cartwright
  * Authors:  Reed A. Cartwright <reed@cartwrig.ht>
  *
  * This file is part of DeNovoGear.
@@ -24,6 +24,8 @@
 #include <tuple>
 #include <cmath>
 #include <locale>
+#include <cstdint>
+#include <climits>
 
 #include <boost/spirit/include/support_ascii.hpp>
 #include <boost/spirit/include/qi_real.hpp>
@@ -38,6 +40,25 @@
 
 namespace dng {
 namespace utility {
+
+typedef int64_t location_t;
+
+constexpr location_t LOCATION_MAX = ((static_cast<location_t>(INT32_MAX) << 32) | INT32_MAX);
+
+inline location_t make_location(int t, int p) {
+    assert((t & INT32_MAX) == t && (p & INT32_MAX) == p);
+    return (static_cast<location_t>(t) << 32) | p;
+}
+inline int location_to_target(location_t u) {
+    int x = static_cast<int>(u >> 32);
+    assert((x & INT32_MAX) == x);
+    return x;
+}
+inline int location_to_position(location_t u) {
+    int x = static_cast<int>(u & UINT32_MAX); // yes, UINT32_MAX
+    assert((x & INT32_MAX) == x);
+    return x;
+}
 
 template<class A, class B, std::size_t N>
 std::size_t key_switch(A &ss, const B(&key)[N]) {
@@ -68,7 +89,7 @@ std::pair<std::vector<double>, bool> parse_double_list(const S &str,
     namespace qi = boost::spirit::qi;
     std::vector<double> f;
     f.reserve(sz_hint);
-    boost::spirit::ascii::space_type space;
+    boost::spirit::standard::space_type space;
     auto b = boost::begin(str);
     auto e = boost::end(str);
     bool r = qi::phrase_parse(b, e, qi::double_ % sep, space, f);
@@ -129,6 +150,8 @@ inline std::pair<std::string, std::string> extract_file_type(const std::string &
 }
 
 }
+using utility::location_t;
+
 } // namespace dng::utility
 
 #endif

--- a/src/lib/call.cc
+++ b/src/lib/call.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2015 Reed A. Cartwright
+ * Copyright (c) 2014-2016 Reed A. Cartwright
  * Copyright (c) 2015 Kael Dai
  * Authors:  Reed A. Cartwright <reed@cartwrig.ht>
  *           Kael Dai <kdai1@asu.edu>
@@ -21,8 +21,6 @@
 
 #include <cstdlib>
 #include <fstream>
-#include <iterator>
-#include <iosfwd>
 
 #include <iostream>
 #include <iomanip>
@@ -31,7 +29,6 @@
 #include <sstream>
 #include <string>
 
-#include <boost/range/iterator_range.hpp>
 #include <boost/range/algorithm/replace.hpp>
 #include <boost/range/algorithm/max_element.hpp>
 
@@ -50,28 +47,19 @@
 #include <dng/vcfpileup.h>
 #include <dng/mutation.h>
 #include <dng/stats.h>
+#include <dng/io/utility.h>
 
 #include <htslib/faidx.h>
 #include <htslib/khash.h>
 
 #include "version.h"
 
-using namespace dng::task;
 using namespace dng;
-
-// Helper function that mimics boost::istream_range
-template<class Elem, class Traits> inline
-boost::iterator_range<std::istreambuf_iterator<Elem, Traits> >
-istreambuf_range(std::basic_istream<Elem, Traits> &in) {
-    return boost::iterator_range<std::istreambuf_iterator<Elem, Traits>>(
-               std::istreambuf_iterator<Elem, Traits>(in),
-               std::istreambuf_iterator<Elem, Traits>());
-}
 
 // Helper function to determines if output should be bcf file, vcf file, or stdout. Also
 // parses filename "bcf:<file>" --> "<file>"
 std::pair<std::string, std::string> vcf_get_output_mode(
-    Call::argument_type &arg) {
+    task::Call::argument_type &arg) {
     using boost::algorithm::iequals;
 
     if(arg.output.empty() || arg.output == "-")
@@ -125,7 +113,7 @@ std::string vcf_command_line_text(const char *arg, std::string val) {
 }
 
 // Helper function for writing the vcf header information
-void vcf_add_header_text(hts::bcf::File &vcfout, Call::argument_type &arg) {
+void vcf_add_header_text(hts::bcf::File &vcfout, task::Call::argument_type &arg) {
     using namespace std;
     string line{"##DeNovoGearCommandLine=<ID=dng-call,Version="
                 PACKAGE_VERSION ","};
@@ -286,11 +274,13 @@ std::vector<std::string> extract_contigs(const bcf_hdr_t *hdr) {
 
 // The main loop for dng-call application
 // argument_type arg holds the processed command line arguments
-int Call::operator()(Call::argument_type &arg) {
+int task::Call::operator()(Call::argument_type &arg) {
     using namespace std;
     using namespace hts::bcf;
     using dng::utility::lphred;
     using dng::utility::phred;
+    using dng::utility::location_to_target;
+    using dng::utility::location_to_position;
 
     // Parse pedigree from file
     dng::io::Pedigree ped;
@@ -300,7 +290,7 @@ int Call::operator()(Call::argument_type &arg) {
             throw std::runtime_error(
                 "unable to open pedigree file '" + arg.ped + "'.");
         }
-        ped.Parse(istreambuf_range(ped_file));
+        ped.Parse(io::istreambuf_range(ped_file));
     } else {
         throw std::runtime_error("pedigree file was not specified.");
     }
@@ -365,11 +355,20 @@ int Call::operator()(Call::argument_type &arg) {
     hts::bcf::File vcfout(out_file.first.c_str(), out_file.second.c_str());
     vcf_add_header_text(vcfout, arg);
 
+    // replace arg.region with the contents of a file if needed
+    io::at_slurp(arg.region);
+
     if(cat == sequence_data) {
         // Wrap input in hts::bam::File
         for(auto && f : indata) {
-       	    bamdata.emplace_back(std::move(f), arg.region.c_str(), arg.fasta.c_str(),
+       	    bamdata.emplace_back(std::move(f), arg.fasta.c_str(),
 				 arg.min_mapqual, arg.header.c_str());
+        }
+        if(!arg.region.empty()) {
+            for(auto && f : bamdata) {
+                auto r = regions::bam_parse(arg.region, f);
+                f.regions(std::move(r));
+            }
         }
 
         // Read header from first file
@@ -386,8 +385,6 @@ int Call::operator()(Call::argument_type &arg) {
         bcfdata.emplace_back(std::move(indata[0]));
         // Read header from first file
         const bcf_hdr_t *h = bcfdata[0].header();
-
-
 
         // Add contigs to header
         for(auto && contig : extract_contigs(h)) {
@@ -444,7 +441,7 @@ int Call::operator()(Call::argument_type &arg) {
     if(cat == sequence_data) {
         const bam_hdr_t *h = bamdata[0].header();
         dng::BamPileup mpileup{rgs.groups(), arg.min_qlen};
-        mpileup(bamdata, [&](const dng::BamPileup::data_type & data, uint64_t loc) {
+        mpileup(bamdata, [&](const dng::BamPileup::data_type & data, utility::location_t loc) {
 
             // Calculate target position and fetch sequence name
             int target_id = location_to_target(loc);

--- a/src/lib/regions.cc
+++ b/src/lib/regions.cc
@@ -41,7 +41,7 @@ namespace qi = boost::spirit::qi;
 namespace phoenix = boost::phoenix;
 
 BOOST_FUSION_ADAPT_STRUCT(dng::regions::detail::raw_parsed_region_t,
-    (int,target),(int,beg),(int,end));
+    (int,target)(int,beg)(int,end));
 
 // uint_parser<unsigned, 10, 1, 3> uint3_p;        //  1..3 digits
 // uint_parser<unsigned, 10, 3, 3> uint3_3_p;      //  exactly 3 digits

--- a/src/lib/regions.cc
+++ b/src/lib/regions.cc
@@ -40,7 +40,8 @@ using namespace dng::regions;
 namespace qi = boost::spirit::qi;
 namespace phoenix = boost::phoenix;
 
-BOOST_FUSION_ADAPT_STRUCT(dng::regions::detail::raw_parsed_region_t, target, beg, end);
+BOOST_FUSION_ADAPT_STRUCT(dng::regions::detail::raw_parsed_region_t,
+    (int,target),(int,beg),(int,end));
 
 // uint_parser<unsigned, 10, 1, 3> uint3_p;        //  1..3 digits
 // uint_parser<unsigned, 10, 3, 3> uint3_3_p;      //  exactly 3 digits

--- a/src/lib/regions.cc
+++ b/src/lib/regions.cc
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2016 Reed A. Cartwright
+ * Authors:  Reed A. Cartwright <reed@cartwrig.ht>
+ *
+ * This file is part of DeNovoGear.
+ *
+ * DeNovoGear is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+#define BOOST_SPIRIT_USE_PHOENIX_V3 1
+
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <algorithm>
+
+#include <dng/regions.h>
+
+#include <boost/fusion/include/std_pair.hpp>
+#include <boost/fusion/include/vector.hpp>
+#include <boost/fusion/include/adapt_struct.hpp>
+
+#include <boost/spirit/include/qi.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
+#include <boost/phoenix/fusion.hpp>
+#include <boost/phoenix/scope/local_variable.hpp>
+
+using namespace dng::regions;
+
+namespace qi = boost::spirit::qi;
+namespace phoenix = boost::phoenix;
+
+BOOST_FUSION_ADAPT_STRUCT(dng::regions::detail::raw_parsed_region_t, target, beg, end);
+
+// uint_parser<unsigned, 10, 1, 3> uint3_p;        //  1..3 digits
+// uint_parser<unsigned, 10, 3, 3> uint3_3_p;      //  exactly 3 digits
+// test_parser("12,345,678", uint3_p >> *(',' >> uint3_3_p));
+
+
+struct make_region_impl {
+    typedef detail::raw_parsed_region_t result_type;
+
+    result_type operator()(std::string s, int b, int e) const {
+        return {s,b,e};
+    }
+    result_type operator()(std::string s, boost::optional<std::pair<int,int>> p) const {
+        if(p) {
+            return {s, (*p).first, (*p).second};
+        }
+        return {s,1,INT_MAX};
+    }
+};
+const phoenix::function<make_region_impl> make_region;
+
+template <typename Iterator, typename Skipper>
+struct regions_grammar :
+qi::grammar<Iterator, detail::raw_parsed_regions_t, Skipper> {
+    typedef std::pair<int,int> pos_t;
+    regions_grammar() : regions_grammar::base_type(start) {
+        using qi::uint_; using qi::char_; using qi::as_string;
+        using qi::attr; using qi::lexeme; using qi::no_skip;
+        using qi::lit;
+        using namespace qi::labels;
+
+        start = region % no_skip[wsp];
+        region = (label >> -(':' >> position))[_val = make_region(_1,_2)];
+        position %= 
+            ((pos[_a = _1] >> ( ('-' >> ( pos | attr(INT_MAX)))
+                              | ('+' >> pos)[_1 = _a+_1-1]
+                              | attr(_a)
+                              ))
+            |(attr(1) >> '-' >> pos)
+            );
+        pos = sudouble | (uint_ >> !lit(',')) | sepint;
+        // We support the format of targets specified in Sam files, except that ':' are disallowed
+        label = as_string[lexeme[char_("!-)+-9;<>-~") >> *char_("!-9;-~")]]; 
+        sepint = lexeme[uint3_p[_val=_1] >> *(',' >> uint3_3_p[_val = 1000*_val+_1])];
+    }
+
+    qi::real_parser<double, qi::strict_ureal_policies<double>> sudouble;
+    qi::uint_parser<unsigned, 10, 1, 3> uint3_p;
+    qi::uint_parser<unsigned, 10, 3, 3> uint3_3_p;
+
+    qi::rule<Iterator, detail::raw_parsed_regions_t, Skipper> start;
+    qi::rule<Iterator, detail::raw_parsed_region_t, Skipper> region;
+    qi::rule<Iterator, std::string(), Skipper> label;
+    qi::rule<Iterator, int(), Skipper> pos, pos_end;
+    qi::rule<Iterator, std::pair<int,int>(), qi::locals<int>, Skipper> position;
+    qi::rule<Iterator, int(), Skipper> sepint;
+
+    Skipper wsp;
+};
+
+
+std::pair<detail::raw_parsed_regions_t,bool> dng::regions::detail::parse_regions(const std::string &text) {
+    namespace ss = boost::spirit::standard;
+    using ss::space;
+    regions_grammar<std::string::const_iterator, ss::space_type> parser_grammar;
+
+    std::string::const_iterator first = text.begin();
+    raw_parsed_regions_t regions;
+    bool success = qi::phrase_parse(first, text.end(), parser_grammar, space, regions);
+    success = success && (first == text.end());
+    return {regions, success};
+}
+
+hts::bam::regions_t dng::regions::bam_parse(const std::string &text, const hts::bam::File &file) {
+    using hts::bam::region_t;
+    using hts::bam::regions_t;
+    // Parse string
+    auto raw_regions = dng::regions::detail::parse_regions(text);
+    if(!raw_regions.second) {
+        throw(std::runtime_error("Parsing of regions string failed."));
+    }
+    // Return quickly if there are no regions
+    if(raw_regions.first.empty()) {
+        return {};
+    }
+    // Convert raw regions to bam regions
+    regions_t value;
+    for(auto &&r : raw_regions.first) {
+        int tid = file.TargetNameToID(r.target.c_str());
+        int beg = r.beg-1;
+        int end = r.end;
+        if(tid < 0 ) {
+            throw(std::runtime_error("Unknown contig name: '" + r.target + "'"));
+        }
+        if(beg < 0 || end < 0 || beg >= end) {
+            throw(std::runtime_error("Invalid region coordinates: '" +
+                r.target + ":" + std::to_string(beg+1) + "-" + std::to_string(end) + "'" ));
+        }
+        value.push_back({tid,beg,end});
+    }
+    // sort regions in increasing order
+    std::sort(value.begin(), value.end(), [](const region_t &a, const region_t &b) {
+        return std::tie(a.tid, a.beg, a.end) < std::tie(b.tid, b.beg, b.end);
+    });
+    // merge overlapping ranges
+    auto overlapping = [](const region_t &a, const region_t &b) {
+        return a.tid == b.tid && b.beg <= a.end; // assumes sorted range
+    };
+
+    auto first = value.begin();
+    auto last  = value.end();
+    auto result = first;
+    while(++first != last) {
+        if(overlapping(*result, *first)) {
+            result->end = first->end;
+        } else if(++result != first) {
+            *result = std::move(*first);
+        }
+    }
+    ++result;
+    value.erase(result,value.end());
+    return value;
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -101,6 +101,7 @@ foreach(test ${TESTS2})
   get_filename_component(testName ${test} NAME_WE)
   add_executable(${testName} EXCLUDE_FROM_ALL ${test}
           ${CMAKE_SOURCE_DIR}/src/lib/peeling.cc
+          ${CMAKE_SOURCE_DIR}/src/lib/regions.cc
           ##            ../src/lib/likelihood.cc ../src/lib/newick.cc ../src/lib/pedigree.cc
           ##            ../src/lib/mutation.cc ../src/lib/stats.cc
           )

--- a/test/src/lib/test2_regions.cc
+++ b/test/src/lib/test2_regions.cc
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2016 Reed A. Cartwright
+ * Authors:  Reed A. Cartwright <reed@cartwrig.ht>
+ *
+ * This file is part of DeNovoGear.
+ *
+ * DeNovoGear is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+#define BOOST_TEST_MODULE dng::lib::regions
+
+#include <dng/regions.h>
+
+using namespace dng::regions;
+
+namespace dng { namespace regions { namespace detail {
+bool operator==(const raw_parsed_region_t &a, const raw_parsed_region_t &b) {
+    return std::tie(a.target,a.beg,a.end) == std::tie(b.target,b.beg,b.end);
+}
+}}}
+
+namespace hts { namespace bam {
+bool operator==(const region_t &a, const region_t &b) {
+    return std::tie(a.tid,a.beg,a.end) == std::tie(b.tid,b.beg,b.end);
+}
+}}
+
+bool region_parsing(std::string input, detail::raw_parsed_regions_t b ) {
+    std::cerr << "Parsing region '" << input << "': ";
+    auto result = detail::parse_regions(input);
+    if(result.second == false) {
+        std::cerr << "FAIL\n";
+        return false;
+    } else {
+        std::cerr << "SUCCESS\n";
+    }
+    if(result.first == b) {
+        return true;
+    }
+    for(auto &&aa : result.first) {
+        std::cerr << "  result: " << aa.target << "\t" << aa.beg << "\t" << aa.end << "\n";
+    }
+    return false;
+}
+
+bool region_parsing_expect_fail(std::string input) {
+    std::cerr << "Parsing region '" << input << "': ";
+    auto result = detail::parse_regions(input);
+    if(result.second == false) {
+        std::cerr << "FAIL (expected)\n";
+        return true;
+    } else {
+        std::cerr << "SUCCESS (unexpected)\n";
+    }
+    for(auto &&aa : result.first) {
+        std::cerr << "  result: " << aa.target << "\t" << aa.beg << "\t" << aa.end << "\n";
+    }
+    return false;
+}
+
+bool region_bam_parsing(std::string input, hts::bam::File &file, hts::bam::regions_t b ) {
+    hts::bam::regions_t a;
+    try {
+        a = bam_parse(input, file);
+    } catch(std::exception &e) {
+        std::cerr << e.what() << "\n";
+        return false;
+    }
+    if(a == b) {
+        return true;
+    }
+    for(auto &&aa : a) {
+        std::cerr << "    Parsing result: " << aa.tid << "\t" << aa.beg << "\t" << aa.end << "\n";
+    }
+
+    return false;
+}
+
+bool region_bam_parsing_expect_fail(std::string input, hts::bam::File &file) {
+    try {
+        bam_parse(input, file);
+    } catch(std::exception &e) {
+        std::cerr << "    Expected exception: " << e.what() << "\n";
+        return true;
+    }
+    return false;
+}
+
+const char bamtext[]= "data:"
+"@HD\tVN:1.4\tGO:none\tSO:coordinate\n"
+"@SQ\tSN:1\tLN:249250621\n"
+"@SQ\tSN:2\tLN:243199373\n"
+;
+
+BOOST_AUTO_TEST_CASE(test_region_parsing) {
+    BOOST_CHECK(region_parsing_expect_fail("chr1:-"));
+    BOOST_CHECK(region_parsing_expect_fail("chr1:"));
+    BOOST_CHECK(region_parsing_expect_fail("chr1:1-1a1"));
+    
+    BOOST_CHECK(region_parsing("chr1:10-1000", {{"chr1",10,1000}}));
+    BOOST_CHECK(region_parsing("chr1:10-1e3", {{"chr1",10,1000}}));
+    BOOST_CHECK(region_parsing("chr1:10-1.2e3", {{"chr1",10,1200}}));
+    BOOST_CHECK(region_parsing("chr1 : 10 - 1000", {{"chr1",10,1000}}));
+    BOOST_CHECK(region_parsing("chr1:10-",     {{"chr1",10,INT_MAX}}));
+    BOOST_CHECK(region_parsing("chr1:-1000",   {{"chr1",1,1000}}));
+    BOOST_CHECK(region_parsing("chr1:1000",    {{"chr1",1000,1000}}));
+    BOOST_CHECK(region_parsing("chr1:1,000",    {{"chr1",1000,1000}}));
+    BOOST_CHECK(region_parsing("chr1:1.0e3",    {{"chr1",1000,1000}}));
+    BOOST_CHECK(region_parsing("chr1",         {{"chr1",1,INT_MAX}}));
+    BOOST_CHECK(region_parsing("chr1:100,001 -1,001,001",    {{"chr1",100001,1001001}}));
+
+    BOOST_CHECK(region_parsing("chr1:10+1000", {{"chr1",10,1009}}));
+
+    BOOST_CHECK(region_parsing("chr1:10-1000 3:60-100", {{"chr1",10,1000},{"3",60,100}}));
+    BOOST_CHECK(region_parsing("chr1:10-1000  3", {{"chr1",10,1000},{"3",1,INT_MAX}}));
+    BOOST_CHECK(region_parsing("\nchr1\t:\n10\f-\v1000\t\n \f\v3 ", {{"chr1",10,1000},{"3",1,INT_MAX}}));
+    
+    // Open Read our test data from Memory
+    hts::bam::File bamfile(bamtext, "r");
+    // Sanity checks.  If these fail, then other tests will as well
+    BOOST_CHECK(bamfile.is_open() && bamfile.header() != nullptr);
+    BOOST_CHECK(bamfile.TargetNameToID("xyz") == -1);
+    BOOST_CHECK(bamfile.TargetNameToID("1") == 0);
+    BOOST_CHECK(bamfile.TargetNameToID("2") == 1);
+    // Check normal 
+    BOOST_CHECK(region_bam_parsing("1:1-1000", bamfile, {{0,0,1000}}));
+    BOOST_CHECK(region_bam_parsing("1:1-1000 2:1", bamfile, {{0,0,1000},{1,0,1}}));
+    // Check sorting
+    BOOST_CHECK(region_bam_parsing("2:100-120 2:21-30 2:1-20 1:1-5 1:7-10", bamfile, {{0,0,5},{0,6,10},{1,0,30},{1,99,120}}));
+    // Check merging
+    BOOST_CHECK(region_bam_parsing("1:1-1000 1:900-2000", bamfile, {{0,0,2000}}));
+    BOOST_CHECK(region_bam_parsing("2:10-200 2:100-300 1:1-1000 2:200-400", bamfile, {{0,0,1000},{1,9,400}}));
+    // Check expected failures
+    BOOST_CHECK(region_bam_parsing_expect_fail("xyz", bamfile));
+    BOOST_CHECK(region_bam_parsing_expect_fail("1:1000-900", bamfile));
+    BOOST_CHECK(region_bam_parsing_expect_fail("1:1000-999", bamfile));
+}


### PR DESCRIPTION
- Create our own region specification format.
  - chr1:1-100, chr1:1-, chr1:-100, chr1:100, chr1:1+100
- Use our format instead of htslib's
- Support reading bam files across multiple regions
- Add a dng/utility.h and dng/io/utility.h files
- Allow reading regions from file

Fixes #42
## Individual commit messages

added location_t typedef

added mask to dng::utility::make_location for position

began playing with regions

Initial parsing of region works

update regions parser and tests

Updated region parsing

begin work to add multiple regions to hts::bam::File

more work on regions

handle converting raw, parsed regions into bam regions

multiple regions now work with call

added thousands separator support

update character space

added io utilities and the ability to read regions from a file if the argument begins with @
