### PR TITLE
Fixing issue with boost intrusive priviliages in 1.61

### DIFF
--- a/src/include/dng/pool.h
+++ b/src/include/dng/pool.h
@@ -83,7 +83,7 @@ public:
             return;
         }
         // clear inactive as needed
-        if(list_type::safemode_or_autounlink) {
+	if(boost::intrusive::is_safe_autounlink<list_type::value_traits::link_mode>::value) {
             inactive_.clear();
         }
         // enumerate over allocated blocks


### PR DESCRIPTION
I've tested this on boost 1.58 through 1.61. 

For the jenkins nodes I added hcgjenkins13 which has the latest release of boost 1.61.0. The other nodes cover 1.55, 1.58 and 1.60.

Fixes  #148
