### PR TITLE
Hotfix compile error on seq.h

### DIFF
--- a/src/include/dng/seq.h
+++ b/src/include/dng/seq.h
@@ -20,6 +20,8 @@
 #ifndef DNG_SEQ_H
 #define DNG_SEQ_H
 
+#include <cassert>
+
 #include <htslib/hts.h>
 
 #include <dng/detail/unit_test.h>


### PR DESCRIPTION
This error only occur with the following setting on Fedora
- boost 1.55
- CMAKE_BUILD_TYPE=Release

It go the following error message
`rm -rdf *;cmake -DBOOST_ROOT=~/include/boost_1_55_0 -DCMAKE_BUILD_TYPE=Release ..;ctest --output-on-failure -j4 -R seq
`

```
-- Boost version: 1.55.0
...
    Start 19: Unit.dng::seq
1/1 Test #19: Unit.dng::seq ....................***Failed   24.80 sec

In file included from ../Tests/Unit/dng/seq.cc:6:
../src/include/dng/seq.h:32:2: error: use of undeclared identifier 'assert'
        assert(0 <= seq_nt16_table[x] && seq_nt16_table[x] < 16);
        ^
```
