### PR TITLE
Introduce MutationStats class

### DIFF
--- a/Tests/Unit/dng/mutation.cc
+++ b/Tests/Unit/dng/mutation.cc
@@ -27,7 +27,6 @@
 #include "../boost_test_helper.h"
 
 using namespace dng;
-namespace utf = boost::unit_test;
 
 struct CreateMutationMatrix {
 

--- a/Tests/Unit/dng/pedigree.cc
+++ b/Tests/Unit/dng/pedigree.cc
@@ -29,8 +29,6 @@
 #include "../boost_test_helper.h"
 #include "fixture_read_trio_from_file.h"
 
-namespace utf = boost::unit_test;
-
 
 struct FixturePedigree : public ReadTrioFromFile{
 

--- a/src/dng-call.cc
+++ b/src/dng-call.cc
@@ -28,6 +28,7 @@
 
 // http://www.boost.org/development/requirements.html
 // http://google-styleguide.googlecode.com/svn/trunk/cppguide.xml
+// https://github.com/denovogear/denovogear/wiki/donovogear-code-convention
 
 typedef dng::CommandLineApp<dng::task::Call> CallApp;
 

--- a/src/include/dng/find_mutations.h
+++ b/src/include/dng/find_mutations.h
@@ -53,7 +53,7 @@
 #include <dng/mutation.h>
 #include <dng/stats.h>
 #include <dng/io/utility.h>
-
+#include <dng/mutation_stats.h>
 namespace dng {
 
 class FindMutations {
@@ -70,7 +70,7 @@ public:
     struct stats_t {
         float mup;
         float lld;
-        float llh;
+        [[deprecated]]float llh;
         float mux;
 
         bool has_single_mut;
@@ -93,6 +93,8 @@ public:
     bool operator()(const std::vector<depth_t> &depths, int ref_index,
                     stats_t *stats);
 
+    bool CalculateMutationProb(MutationStats &mutation_stats);
+
 protected:
     const dng::Pedigree &pedigree_;
 
@@ -100,7 +102,8 @@ protected:
 
     double min_prob_;
 
-    dng::peel::workspace_t work_;
+    dng::peel::workspace_t work_full_;
+    dng::peel::workspace_t work_nomut_;
 
 
     dng::TransitionVector full_transition_matrices_;
@@ -116,7 +119,6 @@ protected:
     dng::GenotypeArray genotype_prior_[5]; // Holds P(G | theta)
 
     std::array<double, 5> max_entropies_;
-
     std::vector<double> event_;
 
     DNG_UNIT_TEST(test_constructor);

--- a/src/include/dng/hts/hts.h
+++ b/src/include/dng/hts/hts.h
@@ -21,6 +21,7 @@
 #define CXX_HTS_HTS_H
 
 #include <htslib/hts.h>
+#include <cstdlib>
 #include <memory>
 #include <cassert>
 

--- a/src/include/dng/hts/hts.h
+++ b/src/include/dng/hts/hts.h
@@ -53,7 +53,7 @@ public:
         return handle()->format;
     }
     std::string format_description() const {
-        std::unique_ptr<char[], void(*)(void *)> s{hts_format_description(&handle()->format), free};
+        std::unique_ptr<char[], void(*)(void *)> s{hts_format_description(&handle()->format), std::free};
         return {s.get()};
     }
 

--- a/src/include/dng/mutation_stats.h
+++ b/src/include/dng/mutation_stats.h
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2016 Steven H. Wu
+ * Authors:  Steven H. Wu <stevenwu@asu.edu>
+ *
+ * This file is part of DeNovoGear.
+ *
+ * DeNovoGear is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+#ifndef DENOVOGEAR_MUTATION_STATS_H
+#define DENOVOGEAR_MUTATION_STATS_H
+
+#include <string>
+#include <vector>
+
+#include <dng/hts/bcf.h>
+#include <dng/matrix.h>
+#include <dng/peeling.h>
+#include <dng/pedigree.h>
+#include <dng/mutation.h>
+#include <dng/detail/unit_test.h>
+
+//TODO(SW): Need to change all test cases before remove entropy calculation
+#define CALCULATE_ENTROPY 1
+
+class MutationStats {
+
+public:
+
+	MutationStats(double min_prob);
+
+	bool CalculateMutationProb(const dng::peel::workspace_t &work_nomut,
+			const dng::peel::workspace_t &work_full);
+
+	void SetScaledLogLikelihood(double scale);
+
+	void SetGenotypeLikelihoods(const dng::peel::workspace_t &workspace,
+			const int depth_size);
+
+	void SetPosteriorProbabilities(const dng::peel::workspace_t &workspace);
+
+//PR_NOTE(SW): Functions for the next PR
+//	void CalculateExpectedMutation(dng::peel::workspace_t &work_full,
+//			dng::TransitionVector &mean_matrices);
+//
+//	void CalculateNodeMutation(dng::peel::workspace_t &work_full,
+//			dng::TransitionVector &posmut_transition_matrices);
+//
+//	void CalculateDenovoMutation(dng::peel::workspace_t &work_nomut,
+//			dng::TransitionVector &onemut_transition_matrices,
+//			const dng::Pedigree &pedigree);
+
+public:
+	//TODO(SW): think about whether these should be public or private?
+	float mup_;
+	float lld_;
+	[[deprecated]] float llh_;
+	float lls_;
+	float mux_;
+
+	bool has_single_mut_;
+	float mu1p_;
+
+	std::string dnt_;
+	std::string dnl_;
+	int32_t dnq_;
+	[[deprecated]]int32_t dnc_;
+
+	dng::IndividualVector posterior_probabilities_;
+	dng::IndividualVector genotype_likelihoods_;
+	std::vector<float> node_mup_;
+	std::vector<float> node_mu1p_;
+
+	std::vector<int32_t> best_genotypes_; //.resize(2 * num_nodes);
+	std::vector<int32_t> genotype_qualities_; //(num_nodes);
+	std::vector<float> gp_scores_; //(gt_count * num_nodes);
+	std::vector<float> gl_scores_; //(gt_count * num_nodes, hts::bcf::float_missing);
+
+private:
+
+	double min_prob_;
+	double logdata_;
+	double logdata_nomut_;
+
+//PR_NOTE(SW): Functions for the next PR
+//	void SetExactlyOneMutation(double total);
+//
+//	void SetNodeCore(std::vector<float> &stats,
+//			const std::vector<double> &event,
+//			std::size_t first_nonfounder_index);
+//
+//	void UpdateMaxDeNovoMutation(const Eigen::ArrayXXd &mat, size_t &index,
+//			double &max_coeff, size_t &dn_row, size_t &dn_col, size_t &dn_loc);
+//#if CALCULATE_ENTROPY == 1
+//public:
+//	[[deprecated]]
+//	void CalculateEntropy(dng::peel::workspace_t &work_nomut,
+//			dng::TransitionVector &onemut_transition_matrices,
+//			std::array<double, 5> max_entropies, std::size_t ref_index);
+//#endif
+
+};
+
+#endif //DENOVOGEAR_MUTATION_STATS_H

--- a/src/include/dng/pedigree.h
+++ b/src/include/dng/pedigree.h
@@ -65,6 +65,7 @@ public:
         for(auto r : roots_) {
             ret += log((work.lower[r] * work.upper[r]).sum());
         }
+        work.forward_result = ret;
         return ret;
     }
 

--- a/src/include/dng/peeling.h
+++ b/src/include/dng/peeling.h
@@ -49,7 +49,7 @@ struct workspace_t {
     ParentVector super; // Holds P(~Descendent_Data & G=g) for parent nodes
 
     bool dirty_lower = false;
-
+    double forward_result;
     // Temporary data used by some peeling ops
     PairedGenotypeArray paired_buffer;
 

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library(libdng STATIC
   newick.cc
   pedigree.cc
   peeling.cc
+  mutation_stats.cc
   mutation.cc
   stats.cc
   regions.cc

--- a/src/lib/mutation_stats.cc
+++ b/src/lib/mutation_stats.cc
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2014-2016 Reed A. Cartwright
+ * Copyright (c) 2016 Steven H. Wu
+ * Authors:  Reed A. Cartwright <reed@cartwrig.ht>
+ *           Steven H. Wu <stevenwu@asu.edu>
+ *
+ *
+ * This file is part of DeNovoGear.
+ *
+ * DeNovoGear is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <dng/mutation_stats.h>
+
+MutationStats::MutationStats(double min_prob) :
+		min_prob_(min_prob) {
+}
+
+bool MutationStats::CalculateMutationProb(
+		const dng::peel::workspace_t &work_nomut,
+		const dng::peel::workspace_t &work_full) {
+	// P(mutation | Data ; model) = 1 - [ P(Data, nomut ; model) / P(Data ; model) ]
+	logdata_nomut_ = work_nomut.forward_result;
+	logdata_ = work_full.forward_result;
+	mup_ = static_cast<float>(-std::expm1(logdata_nomut_ - logdata_));
+
+	return mup_ < min_prob_;
+}
+
+void MutationStats::SetScaledLogLikelihood(double scale) {
+	lld_ = static_cast<float>((logdata_ + scale) / M_LN10);
+//    llh_ = static_cast<float>( logdata_ / M_LN10);
+
+}
+
+void MutationStats::SetGenotypeLikelihoods(
+		const dng::peel::workspace_t &workspace, const int depth_size) {
+
+	genotype_likelihoods_.resize(workspace.num_nodes);
+	for (std::size_t u = 0; u < depth_size; ++u) {
+		std::size_t pos = workspace.library_nodes.first + u;
+		genotype_likelihoods_[pos] = workspace.lower[pos].log() / M_LN10;
+		//TODO(SW): Eigen 3.3 might have log10()
+	}
+}
+
+void MutationStats::SetPosteriorProbabilities(
+		const dng::peel::workspace_t &workspace) {
+
+	posterior_probabilities_.resize(workspace.num_nodes);
+	for (std::size_t i = 0; i < workspace.num_nodes; ++i) {
+//        posterior_probabilities_[i] = WORKSPACE_MULTIPLE_UPPER_LOWER(workspace, i);
+		posterior_probabilities_[i] = (workspace.upper[i] * workspace.lower[i]);
+		posterior_probabilities_[i] /= posterior_probabilities_[i].sum();
+	}
+
+}


### PR DESCRIPTION
- This is part of the multi PR mentioned in issue #161.
- The idea is to make `call.cc` and `FindMutation` Class more readable by letting `MutationStats` class handle all(most) of the stats storage and calculation.
- This PR only move some stats from FindMutations, including mutation_probabilities, genotype likelihood, and posterior probabilities. Others stats, such as node prob, and expected prob will be in the next PR.
- Use separate `workspace_t` in `FindMutation` as suggested in TODO tag. Different `workspace_t` for `nomut` and `full`. (maybe, maybe not?)
  - Currently, we reassign `mutation_stasts` back to `stats_t`. This avoid major changes in call.cc at this stage. Eventually, these and `stats_t` will be removed, maybe a few PR later

Minor changes
- Add `#define CALCULATE_ENTROPY 1`, easier to remove entropy stats later

TODO:
- Need to ensure PeelBackwards only called once.
