### PR TITLE
Remove requirement for PythonLibs in cmake

### DIFF
--- a/src/treecall/CMakeLists.txt
+++ b/src/treecall/CMakeLists.txt
@@ -1,5 +1,4 @@
 find_package(PythonInterp 2.7)
-find_package(PythonLibs 2.7)
 
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/treecall2.py.in"
   "${CMAKE_CURRENT_BINARY_DIR}/treecall2.py" @ONLY)


### PR DESCRIPTION
Wasn't being used anyway

Fixes #91
Fixes #122 
