### PR TITLE
Trim white space in ped file

### DIFF
--- a/src/include/dng/io/ped.h
+++ b/src/include/dng/io/ped.h
@@ -32,6 +32,7 @@
 #include <boost/multi_index/identity.hpp>
 #include <boost/multi_index/ordered_index.hpp>
 #include <boost/multi_index/random_access_index.hpp>
+#include <boost/algorithm/string.hpp>
 
 #include <dng/utility.h>
 #include <dng/io/utility.h>
@@ -121,6 +122,7 @@ public:
             }
             // Add token to the current row
             string_table.back()[k] = *tok_iter;
+            boost::trim(string_table.back()[k]);
             k += 1;
         }
         // Build map of unique child names


### PR DESCRIPTION
If users insert random spaces in the ped file,
the parse in `ped.h` will break under current implementation.

The normal ped file looks like the following

```
1\t1\t0\t0\t1\tNA12891
1\t2\t0\t0\t2\tNA12892
1\t3\t1\t2\t1\tNA12878
```

Currently, the parser will break if there are random spaces, e.g.

```
1\t_1\t0\t0\t1\tNA12891
1\t2\t0\t0\t_2\tNA12892
1\t3\t1\t2_\t1\tNA12878
```

`_` denote space here, for easier reading
- Individual 1 with id `_1`, does not match with father `1`.
- Individual 2 with id `2`, does not match with mother `2_`.
- `ParseSex` can't parse sex `_2`, this will generate error in `RelationshipGraph`.
