### PR TITLE
Hotfix for single individual Relationship Graph.

### DIFF
--- a/src/lib/relationship_graph.cc
+++ b/src/lib/relationship_graph.cc
@@ -559,8 +559,9 @@ void dng::RelationshipGraph::SimplifyPedigree(dng::Graph &pedigree_graph) {
         } else if (children >= 2 || spouses != 0) {
             /*noop*/;
         }
-        else if (ancestors>0) {
-            edge_t edge_trio[3];// TODO: How "wrong" does the graph has to be to have ancestor>2? should be impossible (at least logically)
+        else if (ancestors > 0) {
+            assert(ancestors < 3); // TODO: How "wrong" does the graph has to be to have ancestor>2? should be impossible (at least logically)
+            edge_t edge_trio[3];
             vertex_t vertex_trio[3];//
             int child_index = ancestors;
             for (size_t j = 0; j <= ancestors; ++j) {

--- a/src/lib/relationship_graph.cc
+++ b/src/lib/relationship_graph.cc
@@ -559,7 +559,7 @@ void dng::RelationshipGraph::SimplifyPedigree(dng::Graph &pedigree_graph) {
         } else if (children >= 2 || spouses != 0) {
             /*noop*/;
         }
-        else {
+        else if (ancestors>0) {
             edge_t edge_trio[3];// TODO: How "wrong" does the graph has to be to have ancestor>2? should be impossible (at least logically)
             vertex_t vertex_trio[3];//
             int child_index = ancestors;


### PR DESCRIPTION
Previous refactor removed nodes with this condition `ancestor==0 && children==1`. This will fail if there is single individual, single sample, multiple libs. It's not a connected pedigree, but still a valid graph.