### PR TITLE
Fix issue #214, error when converting tad to ad

### DIFF
--- a/src/include/dng/io/ad.h
+++ b/src/include/dng/io/ad.h
@@ -236,6 +236,7 @@ void Ad::CopyHeader(const Ad& ad) {
     num_libraries_ = ad.num_libraries_;
     contig_map_ = ad.contig_map_;
     extra_headers_ = ad.extra_headers_;
+    last_data_.assign(num_libraries_, 0);
 }
 
 inline


### PR DESCRIPTION
Output after the fix

```
$ dng-pileup pTest1.ad -o pTest1a2t.tad
$ dng-pileup pTest1.tad -o pTest1t2a.ad
$ diff -s pTest1.ad pTest1t2a.ad
Files pTest1.ad and pTest1t2a.ad are identical
$ diff -s pTest1.tad pTest1a2t.tad
Files pTest1.tad and pTest1a2t.tad are identical
```

The segmentation fault was cause at
line 828 in `ad.cc` -> `last_data_[i] = line.data()[i];`
Where `last_data_` in `io::Ad output` was not initilised.