### PR TITLE
Fix issue #218, permission issue with dng help

### DIFF
--- a/src/dng.sh.in
+++ b/src/dng.sh.in
@@ -97,7 +97,7 @@ dng_help() {
 	    return $?
     fi
 
-    ext_cmds=`find $DNG_LIBEXEC_DIR -maxdepth 1 -type f -perm +111 -name "dng-*" -print | sed -e 's/.*dng-//'`
+    ext_cmds=`find $DNG_LIBEXEC_DIR -maxdepth 1 -type f -perm /111 -name "dng-*" -print | sed -e 's/.*dng-//'`
     cmds="$int_cmds $ext_cmds"
     sorted=`echo $cmds | tr ' ' '\n' | sort | tr '\n' ' '`
 


### PR DESCRIPTION
When running `dng help` the syntax was deprecated and is now updated to `-perm /mode`.