### PR TITLE
Simplify Mutation Rate UI

### DIFF
--- a/Tests/DngCall/BamTest.cmake.in
+++ b/Tests/DngCall/BamTest.cmake.in
@@ -1,7 +1,7 @@
 ###############################################################################
 # Test if dng-call can identify mutations correctly from a bam file
 
-set(Trio-CMD @DNG_CALL_EXE@ -f sample-5.3_ref.fasta.gz -p ceu.ped -m 0.001 test1.bam)
+set(Trio-CMD @DNG_CALL_EXE@ --mu-somatic 1e-8 --mu-library 1e-8 -f sample-5.3_ref.fasta.gz -p ceu.ped -m 0.001 test1.bam)
 set(Trio-WD "@TESTDATA_DIR@/sample_5_3/")
 set(Trio-RESULT 0)
 set(Trio-STDOUT

--- a/Tests/DngCall/CramTest.cmake.in
+++ b/Tests/DngCall/CramTest.cmake.in
@@ -1,7 +1,7 @@
 ###############################################################################
 # Test if dng-call can identify mutations correctly from a cram file
 
-set(Trio-CMD @DNG_CALL_EXE@ -f sample-5.3_ref.fasta.gz -p ceu.ped -m 0.001 test1.cram)
+set(Trio-CMD @DNG_CALL_EXE@ --mu-somatic 1e-8 --mu-library 1e-8 -f sample-5.3_ref.fasta.gz -p ceu.ped -m 0.001 test1.cram)
 set(Trio-WD "@TESTDATA_DIR@/sample_5_3/")
 set(Trio-RESULT 0)
 set(Trio-STDOUT

--- a/Tests/DngCall/TadTest.cmake.in
+++ b/Tests/DngCall/TadTest.cmake.in
@@ -1,4 +1,4 @@
-set(Trio-CMD @DNG_CALL_EXE@ -f sample-5.3_ref.fasta.gz -p ceu.ped -m 0.001 test1.tad)
+set(Trio-CMD @DNG_CALL_EXE@ --mu-somatic 1e-8 --mu-library 1e-8 -f sample-5.3_ref.fasta.gz -p ceu.ped -m 0.001 test1.tad)
 set(Trio-WD "@TESTDATA_DIR@/sample_5_3/")
 set(Trio-RESULT 0)
 set(Trio-STDOUT
@@ -12,7 +12,7 @@ set(Trio-STDOUT
   "0/0:147:1,1\\.99685e-15,0,1\\.99954e-26,0,0:3\\.33278e-05:3\\.33278e-05:0,-18\\.4896,-138\\.087,-21\\.9623,-138\\.388,-141\\.865:77:76,1,0"
 )
 
-set(TrioExtraCol-CMD @DNG_CALL_EXE@ -f sample-5.3_ref.fasta.gz -p ceu.ped -m 0.001 test1_extra.tad)
+set(TrioExtraCol-CMD @DNG_CALL_EXE@ --mu-somatic 1e-8 --mu-library 1e-8 -f sample-5.3_ref.fasta.gz -p ceu.ped -m 0.001 test1_extra.tad)
 set(TrioExtraCol-WD "@TESTDATA_DIR@/sample_5_3/")
 set(TrioExtraCol-RESULT 0)
 set(TrioExtraCol-STDOUT
@@ -26,7 +26,7 @@ set(TrioExtraCol-STDOUT
   "0/0:147:1,1\\.99685e-15,0,1\\.99954e-26,0,0:3\\.33278e-05:3\\.33278e-05:0,-18\\.4896,-138\\.087,-21\\.9623,-138\\.388,-141\\.865:77:76,1,0"
   )
 
-set(Ceph-CMD @DNG_CALL_EXE@ -p ceph_trio.ped ceph_trio.tad)
+set(Ceph-CMD @DNG_CALL_EXE@ --mu-somatic 1e-8 --mu-library 1e-8 -p ceph_trio.ped ceph_trio.tad)
 set(Ceph-WD "@TESTDATA_DIR@/ceph1463/")
 set(Ceph-RESULT 0)
 set(Ceph-STDOUT

--- a/Tests/DngCall/VcfTest.cmake.in
+++ b/Tests/DngCall/VcfTest.cmake.in
@@ -1,4 +1,4 @@
-set(Trio-CMD @DNG_CALL_EXE@ -f sample-5.3_ref.fasta.gz -p ceu.ped -m 0 test1.vcf)
+set(Trio-CMD @DNG_CALL_EXE@ --mu-somatic 1e-8 --mu-library 1e-8 -f sample-5.3_ref.fasta.gz -p ceu.ped -m 0 test1.vcf)
 set(Trio-WD "@TESTDATA_DIR@/sample_5_3/")
 set(Trio-RESULT 0)
 set(Trio-STDOUT
@@ -12,7 +12,7 @@ set(Trio-STDOUT
 "0/0:147:1,1\\.99685e-15,0,1\\.99954e-26,0,0:3\\.33278e-05:3\\.33278e-05:0,-18\\.4896,-138\\.087,-21\\.9623,-138\\.388,-141\\.865:77:76,1,0"
 )
 
-set(TrioAlt-CMD @DNG_CALL_EXE@ -f sample-5.3_ref.fasta.gz -p ceu.ped -m 0.001 test2.vcf)
+set(TrioAlt-CMD @DNG_CALL_EXE@ --mu-somatic 1e-8 --mu-library 1e-8 -f sample-5.3_ref.fasta.gz -p ceu.ped -m 0.001 test2.vcf)
 set(TrioAlt-WD "@TESTDATA_DIR@/sample_5_3/")
 set(TrioAlt-RESULT 0)
 set(TrioAlt-STDOUT
@@ -26,7 +26,7 @@ set(TrioAlt-STDOUT-FAIL
   "5\t126385929\t\\.\tG\tX"
 )
 
-set(TrioAltRegions-CMD @DNG_CALL_EXE@ -f sample-5.3_ref.fasta.gz -p ceu.ped -m 0.001 -r 5:126385921-126385925 test2.vcf.gz)
+set(TrioAltRegions-CMD @DNG_CALL_EXE@ --mu-somatic 1e-8 --mu-library 1e-8 -f sample-5.3_ref.fasta.gz -p ceu.ped -m 0.001 -r 5:126385921-126385925 test2.vcf.gz)
 set(TrioAltRegions-WD "@TESTDATA_DIR@/sample_5_3/")
 set(TrioAltRegions-RESULT 0)
 set(TrioAltRegions-STDOUT
@@ -40,7 +40,7 @@ set(TrioAltRegions-STDOUT-FAIL
   "5\t126385929\t\\.\tG\tX"
 )
 
-set(TrioExtraCol-CMD @DNG_CALL_EXE@ -f sample-5.3_ref.fasta.gz -p ceu.ped -m 0.001 test1_extra.vcf)
+set(TrioExtraCol-CMD @DNG_CALL_EXE@ --mu-somatic 1e-8 --mu-library 1e-8 -f sample-5.3_ref.fasta.gz -p ceu.ped -m 0.001 test1_extra.vcf)
 set(TrioExtraCol-WD "@TESTDATA_DIR@/sample_5_3/")
 set(TrioExtraCol-RESULT 0)
 set(TrioExtraCol-STDOUT

--- a/Tests/Unit/dng/log_probability.cc
+++ b/Tests/Unit/dng/log_probability.cc
@@ -63,7 +63,7 @@ RelationshipGraph rel_graph = []() -> RelationshipGraph {
     ped.AddMember("Eve","Dad","Mom",Sex::Female,"");
 
     RelationshipGraph g;
-    g.Construct(ped, libs, 1e-8, 1e-8, 1e-8);
+    g.Construct(ped, libs, 1e-8, 1e-8, 1e-8,true);
     return g;
 }();
 

--- a/Tests/Unit/dng/relationship_graph.cc
+++ b/Tests/Unit/dng/relationship_graph.cc
@@ -273,7 +273,7 @@ BOOST_AUTO_TEST_CASE(test_RelationshipGraph_Construct_nodes) {
         //Construct Graph
         RelationshipGraph graph;
         BOOST_REQUIRE_NO_THROW(graph.Construct(quad_ped, quad_libs,
-            InheritanceModel::Autosomal, 1e-8, 3e-8, 5e-8));
+            InheritanceModel::Autosomal, 1e-8, 3e-8, 5e-8,true));
 
         float lsg = 9e-8f; // library-somatic-germline
         float ls  = 8e-8f; // library-somatic
@@ -294,7 +294,7 @@ BOOST_AUTO_TEST_CASE(test_RelationshipGraph_Construct_nodes) {
         //Construct Graph
         RelationshipGraph graph;
         BOOST_REQUIRE_NO_THROW(graph.Construct(quad_ped, quad_libs,
-            InheritanceModel::XLinked, 1e-8, 3e-8, 5e-8));
+            InheritanceModel::XLinked, 1e-8, 3e-8, 5e-8,true));
 
         float lsg = 9e-8f; // library-somatic-germline
         float ls  = 8e-8f; // library-somatic
@@ -315,7 +315,7 @@ BOOST_AUTO_TEST_CASE(test_RelationshipGraph_Construct_nodes) {
         //Construct Graph
         RelationshipGraph graph;
         BOOST_REQUIRE_NO_THROW(graph.Construct(quad_ped, quad_libs,
-            InheritanceModel::YLinked, 1e-8, 3e-8, 5e-8));
+            InheritanceModel::YLinked, 1e-8, 3e-8, 5e-8,true));
 
         float lsg = 9e-8f; // library-somatic-germline
         float ls  = 8e-8f; // library-somatic
@@ -333,7 +333,7 @@ BOOST_AUTO_TEST_CASE(test_RelationshipGraph_Construct_nodes) {
         //Construct Graph
         RelationshipGraph graph;
         BOOST_REQUIRE_NO_THROW(graph.Construct(quad_ped, quad_libs,
-            InheritanceModel::ZLinked, 1e-8, 3e-8, 5e-8));
+            InheritanceModel::ZLinked, 1e-8, 3e-8, 5e-8,true));
 
         float lsg = 9e-8f; // library-somatic-germline
         float ls  = 8e-8f; // library-somatic
@@ -354,7 +354,7 @@ BOOST_AUTO_TEST_CASE(test_RelationshipGraph_Construct_nodes) {
         //Construct Graph
         RelationshipGraph graph;
         BOOST_REQUIRE_NO_THROW(graph.Construct(quad_ped, quad_libs,
-            InheritanceModel::WLinked, 1e-8, 3e-8, 5e-8));
+            InheritanceModel::WLinked, 1e-8, 3e-8, 5e-8,true));
 
         float lsg = 9e-8f; // library-somatic-germline
         float ls  = 8e-8f; // library-somatic
@@ -372,7 +372,7 @@ BOOST_AUTO_TEST_CASE(test_RelationshipGraph_Construct_nodes) {
         //Construct Graph
         RelationshipGraph graph;
         BOOST_REQUIRE_NO_THROW(graph.Construct(quad_ped, quad_libs,
-            InheritanceModel::Maternal, 1e-8, 3e-8, 5e-8));
+            InheritanceModel::Maternal, 1e-8, 3e-8, 5e-8,true));
 
         float lsg = 9e-8f; // library-somatic-germline
         float ls  = 8e-8f; // library-somatic
@@ -393,7 +393,7 @@ BOOST_AUTO_TEST_CASE(test_RelationshipGraph_Construct_nodes) {
         //Construct Graph
         RelationshipGraph graph;
         BOOST_REQUIRE_NO_THROW(graph.Construct(quad_ped, quad_libs,
-            InheritanceModel::Paternal, 1e-8, 3e-8, 5e-8));
+            InheritanceModel::Paternal, 1e-8, 3e-8, 5e-8,true));
 
         float lsg = 9e-8f; // library-somatic-germline
         float ls  = 8e-8f; // library-somatic
@@ -413,7 +413,7 @@ BOOST_AUTO_TEST_CASE(test_RelationshipGraph_Construct_nodes) {
 
     //////////////////////////////////////////////////////////////////////////////////////////////
 
-    BOOST_TEST_CONTEXT("graph=somatic_graph") {
+    BOOST_TEST_CONTEXT("graph=somatic_graph_normalized") {
         libraries_t somatic_libs = {
             {"M1A", "M1B", "M2", "M3A", "M3B"},
             {"M1", "M1", "M2", "M3", "M3"}
@@ -427,7 +427,41 @@ BOOST_AUTO_TEST_CASE(test_RelationshipGraph_Construct_nodes) {
         //Construct Graph
         RelationshipGraph graph;
         BOOST_REQUIRE_NO_THROW(graph.Construct(somatic_ped, somatic_libs,
-            InheritanceModel::Autosomal, g, s, l));
+            InheritanceModel::Autosomal, g, s, l, true));
+
+        const expected_graph_nodes_t expected = {
+            {"GL/M", DIPLOID, GERMLINE,  ROOT, FOUNDER, -1, 0.0f, -1, 0.0f, ""},
+            {"SM/unnamed_node_1", DIPLOID, SOMATIC, !ROOT, PAIR, 0, s/3, -1, 0.0f, ""},
+            {"SM/M3", DIPLOID, SOMATIC, !ROOT, PAIR, 1, s/3, -1, 0.0f, ""},
+            {"SM/M12", DIPLOID, SOMATIC, !ROOT, PAIR, 1, s/3, -1, 0.0f, ""},
+            {"SM/M1", DIPLOID, SOMATIC, !ROOT, PAIR, 3, s/3, -1, 0.0f, ""},
+            {"LB/M1/M1A", DIPLOID, LIBRARY, !ROOT, PAIR, 4, l, -1, 0.0f, "M1A"},
+            {"LB/M1/M1B", DIPLOID, LIBRARY, !ROOT, PAIR, 4, l, -1, 0.0f, "M1B"},            
+            {"LB/M2", DIPLOID, LIBRARY, !ROOT, PAIR, 3, l+s/3, -1, 0.0f, "M2"},
+            {"LB/M3/M3A", DIPLOID, LIBRARY, !ROOT, PAIR, 2, l, -1, 0.0f, "M3A"},
+            {"LB/M3/M3B", DIPLOID, LIBRARY, !ROOT, PAIR, 2, l, -1, 0.0f, "M3B"},
+          };
+
+        test(graph, expected);
+    }
+
+    //////////////////////////////////////////////////////////////////////////////////////////////
+
+    BOOST_TEST_CONTEXT("graph=somatic_graph_unnormalized") {
+        libraries_t somatic_libs = {
+            {"M1A", "M1B", "M2", "M3A", "M3B"},
+            {"M1", "M1", "M2", "M3", "M3"}
+        };
+
+        Pedigree somatic_ped;
+        somatic_ped.AddMember("M","0","0",Sex::Female,"((M1,M2)M12,M3);");
+
+        constexpr float g = 1e-8, s = 3e-8, l = 4e-8;
+
+        //Construct Graph
+        RelationshipGraph graph;
+        BOOST_REQUIRE_NO_THROW(graph.Construct(somatic_ped, somatic_libs,
+            InheritanceModel::Autosomal, g, s, l, false));
 
         const expected_graph_nodes_t expected = {
             {"GL/M", DIPLOID, GERMLINE,  ROOT, FOUNDER, -1, 0.0f, -1, 0.0f, ""},
@@ -460,7 +494,7 @@ BOOST_AUTO_TEST_CASE(test_RelationshipGraph_Construct_nodes) {
 
         //Construct Graph
         RelationshipGraph graph;
-        BOOST_REQUIRE_NO_THROW(graph.Construct(ped, libs, InheritanceModel::Autosomal, g, s, l));
+        BOOST_REQUIRE_NO_THROW(graph.Construct(ped, libs, InheritanceModel::Autosomal, g, s, l,true));
 
         const expected_graph_nodes_t expected = {
             {"GL/Mom", DIPLOID, GERMLINE, ROOT, FOUNDER, -1, 0.0f, -1, 0.0f, ""},
@@ -487,7 +521,7 @@ BOOST_AUTO_TEST_CASE(test_RelationshipGraph_Construct_nodes) {
 
         //Construct Graph
         RelationshipGraph graph;
-        BOOST_REQUIRE_NO_THROW(graph.Construct(ped, libs, InheritanceModel::Autosomal, g, s, l));
+        BOOST_REQUIRE_NO_THROW(graph.Construct(ped, libs, InheritanceModel::Autosomal, g, s, l,true));
 
         const expected_graph_nodes_t expected = {
             {"GL/Dad", DIPLOID, GERMLINE, ROOT, FOUNDER, -1, 0.0f, -1, 0.0f, ""},
@@ -514,7 +548,7 @@ BOOST_AUTO_TEST_CASE(test_RelationshipGraph_Construct_nodes) {
 
         //Construct Graph
         RelationshipGraph graph;
-        BOOST_REQUIRE_NO_THROW(graph.Construct(ped, libs, InheritanceModel::Autosomal, g, s, l));
+        BOOST_REQUIRE_NO_THROW(graph.Construct(ped, libs, InheritanceModel::Autosomal, g, s, l,true));
 
         const expected_graph_nodes_t expected = {
             {"GL/Dad", DIPLOID, GERMLINE, ROOT, FOUNDER, -1, 0.0f, -1, 0.0f, ""},
@@ -541,7 +575,7 @@ BOOST_AUTO_TEST_CASE(test_RelationshipGraph_Construct_nodes) {
 
         //Construct Graph
         RelationshipGraph graph;
-        BOOST_REQUIRE_NO_THROW(graph.Construct(ped, libs, InheritanceModel::Autosomal, g, s, l));
+        BOOST_REQUIRE_NO_THROW(graph.Construct(ped, libs, InheritanceModel::Autosomal, g, s, l, true));
 
         const expected_graph_nodes_t expected = {
             {"GL/Mom", DIPLOID, GERMLINE, ROOT, FOUNDER, -1, 0.0f, -1, 0.0f, ""},
@@ -568,7 +602,7 @@ BOOST_AUTO_TEST_CASE(test_RelationshipGraph_Construct_nodes) {
 
         //Construct Graph
         RelationshipGraph graph;
-        BOOST_REQUIRE_NO_THROW(graph.Construct(ped, libs, InheritanceModel::Autosomal, g, s, l));
+        BOOST_REQUIRE_NO_THROW(graph.Construct(ped, libs, InheritanceModel::Autosomal, g, s, l, true));
 
         const expected_graph_nodes_t expected = {
             {"GL/Mom", DIPLOID, GERMLINE, ROOT, FOUNDER, -1, 0.0f, -1, 0.0f, ""},
@@ -595,7 +629,7 @@ BOOST_AUTO_TEST_CASE(test_RelationshipGraph_Construct_nodes) {
 
         //Construct Graph
         RelationshipGraph graph;
-        BOOST_REQUIRE_NO_THROW(graph.Construct(ped, libs, InheritanceModel::Autosomal, g, s, l));
+        BOOST_REQUIRE_NO_THROW(graph.Construct(ped, libs, InheritanceModel::Autosomal, g, s, l, true));
 
         const expected_graph_nodes_t expected = {
             {"GL/Mom", DIPLOID, GERMLINE, ROOT, FOUNDER, -1, 0.0f, -1, 0.0f, ""},
@@ -622,7 +656,7 @@ BOOST_AUTO_TEST_CASE(test_RelationshipGraph_Construct_nodes) {
 
         //Construct Graph
         RelationshipGraph graph;
-        BOOST_REQUIRE_NO_THROW(graph.Construct(ped, libs, InheritanceModel::Autosomal, g, s, l));
+        BOOST_REQUIRE_NO_THROW(graph.Construct(ped, libs, InheritanceModel::Autosomal, g, s, l, true));
 
         const expected_graph_nodes_t expected = {
             {"GL/Mom", DIPLOID, GERMLINE, ROOT, FOUNDER, -1, 0.0f, -1, 0.0f, ""},
@@ -651,7 +685,7 @@ BOOST_AUTO_TEST_CASE(test_RelationshipGraph_Construct_nodes) {
 
         //Construct Graph
         RelationshipGraph graph;
-        BOOST_REQUIRE_NO_THROW(graph.Construct(ped, libs, InheritanceModel::Autosomal, g, s, l));
+        BOOST_REQUIRE_NO_THROW(graph.Construct(ped, libs, InheritanceModel::Autosomal, g, s, l, true));
 
         const expected_graph_nodes_t expected = {
             {"GL/Dad", DIPLOID, GERMLINE,  ROOT, FOUNDER, -1, 0.0f, -1, 0.0f, ""},
@@ -817,6 +851,6 @@ BOOST_AUTO_TEST_CASE(test_RelationshipGraph_Construct_peeler) {
 
     RelationshipGraph graph;
     BOOST_REQUIRE_NO_THROW(graph.Construct(quad_ped, quad_libs,
-        InheritanceModel::Autosomal, g, s, l));
+        InheritanceModel::Autosomal, g, s, l, true));
     test(graph, expected);
 }

--- a/Tests/Unit/dng/relationship_graph.cc
+++ b/Tests/Unit/dng/relationship_graph.cc
@@ -273,7 +273,7 @@ BOOST_AUTO_TEST_CASE(test_RelationshipGraph_Construct_nodes) {
         //Construct Graph
         RelationshipGraph graph;
         BOOST_REQUIRE_NO_THROW(graph.Construct(quad_ped, quad_libs,
-            InheritanceModel::Autosomal, 1e-8, 3e-8, 5e-8,true));
+            InheritanceModel::Autosomal, 1e-8, 3e-8, 5e-8, true));
 
         float lsg = 9e-8f; // library-somatic-germline
         float ls  = 8e-8f; // library-somatic
@@ -294,7 +294,7 @@ BOOST_AUTO_TEST_CASE(test_RelationshipGraph_Construct_nodes) {
         //Construct Graph
         RelationshipGraph graph;
         BOOST_REQUIRE_NO_THROW(graph.Construct(quad_ped, quad_libs,
-            InheritanceModel::XLinked, 1e-8, 3e-8, 5e-8,true));
+            InheritanceModel::XLinked, 1e-8, 3e-8, 5e-8, true));
 
         float lsg = 9e-8f; // library-somatic-germline
         float ls  = 8e-8f; // library-somatic
@@ -315,7 +315,7 @@ BOOST_AUTO_TEST_CASE(test_RelationshipGraph_Construct_nodes) {
         //Construct Graph
         RelationshipGraph graph;
         BOOST_REQUIRE_NO_THROW(graph.Construct(quad_ped, quad_libs,
-            InheritanceModel::YLinked, 1e-8, 3e-8, 5e-8,true));
+            InheritanceModel::YLinked, 1e-8, 3e-8, 5e-8, true));
 
         float lsg = 9e-8f; // library-somatic-germline
         float ls  = 8e-8f; // library-somatic
@@ -333,7 +333,7 @@ BOOST_AUTO_TEST_CASE(test_RelationshipGraph_Construct_nodes) {
         //Construct Graph
         RelationshipGraph graph;
         BOOST_REQUIRE_NO_THROW(graph.Construct(quad_ped, quad_libs,
-            InheritanceModel::ZLinked, 1e-8, 3e-8, 5e-8,true));
+            InheritanceModel::ZLinked, 1e-8, 3e-8, 5e-8, true));
 
         float lsg = 9e-8f; // library-somatic-germline
         float ls  = 8e-8f; // library-somatic
@@ -354,7 +354,7 @@ BOOST_AUTO_TEST_CASE(test_RelationshipGraph_Construct_nodes) {
         //Construct Graph
         RelationshipGraph graph;
         BOOST_REQUIRE_NO_THROW(graph.Construct(quad_ped, quad_libs,
-            InheritanceModel::WLinked, 1e-8, 3e-8, 5e-8,true));
+            InheritanceModel::WLinked, 1e-8, 3e-8, 5e-8, true));
 
         float lsg = 9e-8f; // library-somatic-germline
         float ls  = 8e-8f; // library-somatic
@@ -372,7 +372,7 @@ BOOST_AUTO_TEST_CASE(test_RelationshipGraph_Construct_nodes) {
         //Construct Graph
         RelationshipGraph graph;
         BOOST_REQUIRE_NO_THROW(graph.Construct(quad_ped, quad_libs,
-            InheritanceModel::Maternal, 1e-8, 3e-8, 5e-8,true));
+            InheritanceModel::Maternal, 1e-8, 3e-8, 5e-8, true));
 
         float lsg = 9e-8f; // library-somatic-germline
         float ls  = 8e-8f; // library-somatic
@@ -393,7 +393,7 @@ BOOST_AUTO_TEST_CASE(test_RelationshipGraph_Construct_nodes) {
         //Construct Graph
         RelationshipGraph graph;
         BOOST_REQUIRE_NO_THROW(graph.Construct(quad_ped, quad_libs,
-            InheritanceModel::Paternal, 1e-8, 3e-8, 5e-8,true));
+            InheritanceModel::Paternal, 1e-8, 3e-8, 5e-8, true));
 
         float lsg = 9e-8f; // library-somatic-germline
         float ls  = 8e-8f; // library-somatic
@@ -494,7 +494,7 @@ BOOST_AUTO_TEST_CASE(test_RelationshipGraph_Construct_nodes) {
 
         //Construct Graph
         RelationshipGraph graph;
-        BOOST_REQUIRE_NO_THROW(graph.Construct(ped, libs, InheritanceModel::Autosomal, g, s, l,true));
+        BOOST_REQUIRE_NO_THROW(graph.Construct(ped, libs, InheritanceModel::Autosomal, g, s, l, true));
 
         const expected_graph_nodes_t expected = {
             {"GL/Mom", DIPLOID, GERMLINE, ROOT, FOUNDER, -1, 0.0f, -1, 0.0f, ""},
@@ -521,7 +521,7 @@ BOOST_AUTO_TEST_CASE(test_RelationshipGraph_Construct_nodes) {
 
         //Construct Graph
         RelationshipGraph graph;
-        BOOST_REQUIRE_NO_THROW(graph.Construct(ped, libs, InheritanceModel::Autosomal, g, s, l,true));
+        BOOST_REQUIRE_NO_THROW(graph.Construct(ped, libs, InheritanceModel::Autosomal, g, s, l, true));
 
         const expected_graph_nodes_t expected = {
             {"GL/Dad", DIPLOID, GERMLINE, ROOT, FOUNDER, -1, 0.0f, -1, 0.0f, ""},
@@ -548,7 +548,7 @@ BOOST_AUTO_TEST_CASE(test_RelationshipGraph_Construct_nodes) {
 
         //Construct Graph
         RelationshipGraph graph;
-        BOOST_REQUIRE_NO_THROW(graph.Construct(ped, libs, InheritanceModel::Autosomal, g, s, l,true));
+        BOOST_REQUIRE_NO_THROW(graph.Construct(ped, libs, InheritanceModel::Autosomal, g, s, l, true));
 
         const expected_graph_nodes_t expected = {
             {"GL/Dad", DIPLOID, GERMLINE, ROOT, FOUNDER, -1, 0.0f, -1, 0.0f, ""},

--- a/src/include/dng/app.h
+++ b/src/include/dng/app.h
@@ -27,77 +27,11 @@
 #include <fstream>
 #include <string>
 
+#include <dng/task.h>
+
 #include <boost/filesystem.hpp>
 
-#include <boost/logic/tribool.hpp>
-#include <boost/logic/tribool_io.hpp>
-#include <boost/program_options.hpp>
-namespace po = boost::program_options;
-
 #include "version.h"
-
-// Support the use of tribools in boost::program_options
-namespace boost {
-void validate(boost::any &v, const std::vector<std::string> &xs,
-              boost::tribool *, int) {
-    using namespace boost::program_options;
-    validators::check_first_occurrence(v);
-    std::string s(validators::get_single_string(xs, true));
-
-    for(size_t i = 0; i < s.size(); ++i) {
-        s[i] = char(tolower(s[i]));
-    }
-
-    if(s.empty() || s == "on" || s == "yes" || s == "1" || s == "true") {
-        v = boost::any(boost::tribool(true));
-    } else if(s == "off" || s == "no" || s == "0" || s == "false") {
-        v = boost::any(boost::tribool(false));
-    } else if(s == "null" || s == "maybe" || s == "2" || s == "indeterminate") {
-        v = boost::any(boost::tribool(boost::indeterminate));
-    } else {
-        boost::throw_exception(validation_error(validation_error::invalid_option_value,
-                                                s));
-    }
-}
-#if !defined(BOOST_NO_STD_WSTRING)
-void validate(boost::any &v, const std::vector<std::wstring> &xs,
-              boost::tribool *, int) {
-    using namespace boost::program_options;
-    validators::check_first_occurrence(v);
-    std::wstring s(validators::get_single_string(xs, true));
-
-    for(size_t i = 0; i < s.size(); ++i) {
-        s[i] = char(tolower(s[i]));
-    }
-
-    if(s.empty() || s == L"on" || s == L"yes" || s == L"1" || s == L"true") {
-        v = boost::any(boost::tribool(true));
-    } else if(s == L"off" || s == L"no" || s == L"0" || s == L"false") {
-        v = boost::any(boost::tribool(false));
-    } else if(s == L"null" || s == L"maybe" || s == L"2" || s == L"indeterminate") {
-        v = boost::any(boost::tribool(boost::indeterminate));
-    } else {
-        boost::throw_exception(validation_error(
-                                   validation_error::invalid_option_value));
-    }
-}
-#endif
-}
-
-namespace boost {
-namespace program_options {
-template<>
-typed_value<bool> *value(bool *v) {
-    return bool_switch(v);
-}
-template<>
-typed_value<boost::tribool> *value(boost::tribool *v) {
-    typed_value<boost::tribool> *r = new typed_value<boost::tribool>(v);
-    r->implicit_value(true, "on");
-    return r;
-}
-}
-}
 
 namespace dng {
 
@@ -200,7 +134,7 @@ protected:
         }
 
         cerr << usage_name << " v" PACKAGE_VERSION << "\n";
-        cerr << "Copyright (c) 2014-2015 Reed A. Cartwright, Kael Dai, et al.\n";
+        cerr << "Copyright (c) 2014-2017\n";
         return EXIT_SUCCESS;
     }
 

--- a/src/include/dng/detail/graph.h
+++ b/src/include/dng/detail/graph.h
@@ -85,7 +85,7 @@ typedef boost::graph_traits<Graph>::edge_descriptor edge_t;
 static_assert(std::is_integral<vertex_t>::value,
 	"vertex_t is not an integral type, this violates many assumptions that have been made.");
 
-int parse_newick(const std::string &text, vertex_t root, Graph &graph);
+int parse_newick(const std::string &text, vertex_t root, Graph &graph, bool normalize);
 
 } // namespace graph
 } // namespace detail

--- a/src/include/dng/relationship_graph.h
+++ b/src/include/dng/relationship_graph.h
@@ -80,10 +80,12 @@ public:
 
     bool Construct(const Pedigree& pedigree, const libraries_t& libs,
             InheritanceModel inheritance_model,
-            double mu, double mu_somatic, double mu_library);
+            double mu, double mu_somatic, double mu_library,
+            bool normalize_somatic_trees);
 
     bool Construct(const Pedigree& pedigree, const libraries_t& libs,
-            double mu, double mu_somatic, double mu_library);
+            double mu, double mu_somatic, double mu_library,
+            bool normalize_somatic_trees);
 
     double PeelForwards(peel::workspace_t &work,
                         const TransitionMatrixVector &mat) const {

--- a/src/include/dng/task.h
+++ b/src/include/dng/task.h
@@ -55,7 +55,6 @@ std::ostream& operator<<(std::ostream& os, bool_switch_t b) {
 }
 
 struct arg_t {
-    using bool_switch_t = bool_switch_t;
     std::vector< std::string > input;
 };
 }
@@ -149,7 +148,7 @@ namespace boost {
 namespace program_options {
 template<>
 inline
-typed_value<::dng::task::arg_t::bool_switch_t>*
+typed_value<::dng::task::bool_switch_t>*
 value(::dng::task::bool_switch_t *v) {
     using bool_switch_t = ::dng::task::bool_switch_t;  
     typed_value<bool_switch_t>* r = new typed_value<bool_switch_t>(v);

--- a/src/include/dng/task.h
+++ b/src/include/dng/task.h
@@ -22,11 +22,40 @@
 #define DNG_TASK_H
 
 #include <vector>
+#include <string>
+
+#include <boost/logic/tribool.hpp>
+#include <boost/logic/tribool_io.hpp>
+#include <boost/program_options.hpp>
+namespace po = boost::program_options;
 
 namespace dng {
 
 namespace task {
+
+struct bool_switch_t {
+    bool value;
+
+    explicit bool_switch_t(bool b) : value(b) { }
+    bool_switch_t() { }
+
+    operator bool() {
+        return value;
+    }
+    bool_switch_t& operator =(bool b) {
+        value = b;
+        return *this;
+    }
+};
+
+inline
+std::ostream& operator<<(std::ostream& os, bool_switch_t b) {
+    os << b.value;
+    return os;
+}
+
 struct arg_t {
+    using bool_switch_t = bool_switch_t;
     std::vector< std::string > input;
 };
 }
@@ -43,6 +72,109 @@ public:
 };
 
 } // namespace dng
+
+namespace dng {
+namespace task {
+// Support the use of bool_switch_t and tribool in boost::program_options
+inline
+void validate(boost::any &v, const std::vector<std::string> &xs,
+              bool_switch_t *, int) {
+    boost::program_options::validate(v, xs, (bool*)0, 0);
+    bool b = boost::any_cast<bool>(v);
+    v = boost::any(bool_switch_t{b});
+}
+
+#if !defined(BOOST_NO_STD_WSTRING)
+inline
+void validate(boost::any &v, const std::vector<std::wstring> &xs,
+              bool_switch_t *, int) {
+    boost::program_options::validate(v, xs, (bool*)0, 0);
+    bool b = boost::any_cast<bool>(v);
+    v = boost::any(bool_switch_t{b});
+}
+#endif
+}
+}
+
+namespace boost {
+inline
+void validate(boost::any &v, const std::vector<std::string> &xs,
+              boost::tribool *, int) {
+    using namespace boost::program_options;
+    validators::check_first_occurrence(v);
+    std::string s(validators::get_single_string(xs, true));
+
+    for(size_t i = 0; i < s.size(); ++i) {
+        s[i] = char(tolower(s[i]));
+    }
+
+    if(s.empty() || s == "on" || s == "yes" || s == "1" || s == "true") {
+        v = boost::any(boost::tribool(true));
+    } else if(s == "off" || s == "no" || s == "0" || s == "false") {
+        v = boost::any(boost::tribool(false));
+    } else if(s == "null" || s == "maybe" || s == "2" || s == "indeterminate") {
+        v = boost::any(boost::tribool(boost::indeterminate));
+    } else {
+        boost::throw_exception(validation_error(validation_error::invalid_option_value,
+                                                s));
+    }
+}
+#if !defined(BOOST_NO_STD_WSTRING)
+inline
+void validate(boost::any &v, const std::vector<std::wstring> &xs,
+              boost::tribool *, int) {
+    using namespace boost::program_options;
+    validators::check_first_occurrence(v);
+    std::wstring s(validators::get_single_string(xs, true));
+
+    for(size_t i = 0; i < s.size(); ++i) {
+        s[i] = char(tolower(s[i]));
+    }
+
+    if(s.empty() || s == L"on" || s == L"yes" || s == L"1" || s == L"true") {
+        v = boost::any(boost::tribool(true));
+    } else if(s == L"off" || s == L"no" || s == L"0" || s == L"false") {
+        v = boost::any(boost::tribool(false));
+    } else if(s == L"null" || s == L"maybe" || s == L"2" || s == L"indeterminate") {
+        v = boost::any(boost::tribool(boost::indeterminate));
+    } else {
+        boost::throw_exception(validation_error(
+                                   validation_error::invalid_option_value));
+    }
+}
+#endif
+}
+
+namespace boost {
+namespace program_options {
+template<>
+inline
+typed_value<::dng::task::arg_t::bool_switch_t>*
+value(::dng::task::bool_switch_t *v) {
+    using bool_switch_t = ::dng::task::bool_switch_t;  
+    typed_value<bool_switch_t>* r = new typed_value<bool_switch_t>(v);
+    r->default_value(bool_switch_t{false});
+    r->zero_tokens();
+    return r;
+}
+
+template<>
+inline
+typed_value<bool>* value(bool *v) {
+    typed_value<bool>* r = new typed_value<bool>(v);
+    r->implicit_value(true, "on");
+    return r;
+}
+
+template<>
+inline
+typed_value<boost::tribool>* value(boost::tribool *v) {
+    typed_value<boost::tribool>* r = new typed_value<boost::tribool>(v);
+    r->implicit_value(true, "on");
+    return r;
+}
+}
+}
 
 #endif // DNG_TASK_H
 

--- a/src/include/dng/task/call.xmh
+++ b/src/include/dng/task/call.xmh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Reed A. Cartwright
+ * Copyright (c) 2017 Reed A. Cartwright
  * Authors:  Reed A. Cartwright <reed@cartwrig.ht>
  *
  * This file is part of DeNovoGear.
@@ -27,33 +27,12 @@
  * XM((long)(name), (shortname), "description", typename, defaultvalue)    *
  ***************************************************************************/
 
-XM((fasta), (f), "faidx indexed reference sequence file", std::string, "")
-XM((header), (h), "Location of separate bam header file for read-groups.", 
-   std::string, "")
-XM((min)(qlen), (l), "minimum query length", int, 0)
+#include "model.xm"
+
+#include "input.xm"
+
 XM((min)(prob), (m), "minimum probability for reporting a mutation", double,
    DL(0.01, "0.01"))
-XM((lib)(bias), , "library/sequencing reference bias (ref/alt ratio)", double, 1.02)
-XM((lib)(overdisp), , "library/sequencing overdispersion (pairwise correlation of errors)", double, 0.0005)
-XM((lib)(error), , "library/sequencing error rate (per base-call)", double, 0.0005)
-XM((mu), , "the germline mutation rate", double, DL(1e-8, "1e-8"))
-XM((mu)(somatic), , "the somatic mutation rate", double, DL(1e-8, "1e-8"))
-XM((mu)(library), , "the library prep mutation rate", double, DL(1e-8, "1e-8"))
-XM((model), (M), "Inheritance model", std::string, "autosomal")
-XM((nuc)(freqs), , "nucleotide frequencies in ACGT order", std::string,
-   "0.3,0.2,0.2,0.3")
-XM((output), (o), "output VCF/BCF file", std::string, "-")
-XM((ped), (p), "the pedigree file", std::string, "")
-XM((min)(basequal), (Q), "minimum base quality", int, 13)
-XM((min)(mapqual), (q), "minimum mapping quality", int, 0)
-XM((region), (r), "chromosomal regions", std::string, "")
-XM((ref)(weight), (R), "weight given to reference base for population prior",
-   double, DL(1.0, "1"))
-XM((rgtag), , "combine read groups using @RG tags, e.g. ID, SM, LB, or DS.",
-   std::string, "LB")
-XM((sam)(files), (s), "file containing a list of input filenames, one per line",
-   std::string, "")
-XM((theta), , "the population diversity", double, DL(0.001, "0.001"))
 
 /***************************************************************************
  *    cleanup                                                              *

--- a/src/include/dng/task/input.xm
+++ b/src/include/dng/task/input.xm
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2017 Reed A. Cartwright
+ * Authors:  Reed A. Cartwright <reed@cartwrig.ht>
+ *
+ * This file is part of DeNovoGear.
+ *
+ * DeNovoGear is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/***************************************************************************
+ *    X-Macro List                                                         *
+ *                                                                         *
+ * XM((long)(name), (shortname), "description", typename, defaultvalue)    *
+ ***************************************************************************/
+
+XM((fasta), (f), "faidx indexed reference sequence file", std::string, "")
+XM((header), (h), "Location of separate bam header file for read-groups.", 
+   std::string, "")
+XM((ped), (p), "the pedigree file", std::string, "")
+XM((region), (r), "chromosomal region", std::string, "")
+XM((rgtag), , "combine read groups using @RG tags, e.g. ID, SM, LB, or DS.",
+   std::string, "LB")
+XM((sam)(files), (s), "file containing a list of input filenames, one per line",
+   std::string, "")
+
+XM((output), (o), "output file", std::string, "-")
+
+XM((min)(qlen), (l), "minimum query length", int, 0)
+XM((min)(basequal), (Q), "minimum base quality", int, 13)
+XM((min)(mapqual), (q), "minimum mapping quality", int, 0)
+XM((normalize)(somatic)(trees), , "scale somatic trees to a height of 1", bool, DL(true, "on"))

--- a/src/include/dng/task/loglike.xmh
+++ b/src/include/dng/task/loglike.xmh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Reed A. Cartwright
+ * Copyright (c) 2017 Reed A. Cartwright
  * Authors:  Reed A. Cartwright <reed@cartwrig.ht>
  *
  * This file is part of DeNovoGear.
@@ -27,31 +27,10 @@
  * XM((long)(name), (shortname), "description", typename, defaultvalue)    *
  ***************************************************************************/
 
-XM((fasta), (f), "faidx indexed reference sequence file", std::string, "")
-XM((header), (h), "Location of separate bam header file for read-groups.", 
-   std::string, "")
-XM((min)(qlen), (l), "minimum query length", int, 0)
-XM((lib)(bias), , "library/sequencing reference bias (ref/alt ratio)", double, 1.02)
-XM((lib)(overdisp), , "library/sequencing overdispersion (pairwise correlation of errors)", double, 0.0005)
-XM((lib)(error), , "library/sequencing error rate (per base-call)", double, 0.0005)
-XM((mu), , "the germline mutation rate", double, DL(1e-8, "1e-8"))
-XM((mu)(somatic), , "the somatic mutation rate", double, DL(1e-8, "1e-8"))
-XM((mu)(library), , "the library prep mutation rate", double, DL(1e-8, "1e-8"))
-XM((nuc)(freqs), , "nucleotide frequencies in ACGT order", std::string,
-   "0.3,0.2,0.2,0.3")
-XM((output), (o), "output file", std::string, "-")
-XM((ped), (p), "the pedigree file", std::string, "")
-XM((min)(basequal), (Q), "minimum base quality", int, 13)
-XM((min)(mapqual), (q), "minimum mapping quality", int, 0)
-XM((model), (M), "Inheritance model", std::string, "autosomal")
-XM((region), (r), "chromosomal region", std::string, "")
-XM((ref)(weight), (R), "weight given to reference base for population prior",
-   double, DL(1.0, "1"))
-XM((rgtag), , "combine read groups using @RG tags, e.g. ID, SM, LB, or DS.",
-   std::string, "LB")
-XM((sam)(files), (s), "file containing a list of input filenames, one per line",
-   std::string, "")
-XM((theta), , "the population diversity", double, DL(0.001, "0.001"))
+#include "model.xm"
+
+#include "input.xm"
+
 XM((threads), (t), "the number of worker threads to use", int, 0)
 XM((batch)(size), , "the number of sites to process at a time", int, 100000)
 

--- a/src/include/dng/task/model.xm
+++ b/src/include/dng/task/model.xm
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2017 Reed A. Cartwright
+ * Authors:  Reed A. Cartwright <reed@cartwrig.ht>
+ *
+ * This file is part of DeNovoGear.
+ *
+ * DeNovoGear is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/***************************************************************************
+ *    X-Macro List                                                         *
+ *                                                                         *
+ * XM((long)(name), (shortname), "description", typename, defaultvalue)    *
+ ***************************************************************************/
+
+XM((lib)(bias), , "library/sequencing reference bias (ref/alt ratio)", double, 1.02)
+XM((lib)(error), , "library/sequencing error rate (per base-call)", double, DL(0.0005,"0.0005"))
+XM((lib)(overdisp), , "library/sequencing overdispersion (pairwise correlation of errors)", double, DL(0.0005,"0.0005"))
+XM((mu), , "the germline mutation rate", double, DL(1e-8, "1e-8"))
+XM((mu)(somatic), , "the somatic mutation rate", double, DL(0.0, "0"))
+XM((mu)(library), , "the library prep mutation rate", double, DL(0.0, "0"))
+XM((model), (M), "Inheritance model", std::string, "autosomal")
+XM((nuc)(freqs), , "nucleotide frequencies in ACGT order", std::string, "0.3,0.2,0.2,0.3")
+XM((ref)(weight), (R), "weight given to reference base for population prior",
+   double, DL(1.0, "1"))
+XM((theta), , "the population diversity", double, DL(0.001, "0.001"))

--- a/src/include/dng/task/pileup.xmh
+++ b/src/include/dng/task/pileup.xmh
@@ -27,11 +27,11 @@
  * XM((long)(name), (shortname), "description", typename, defaultvalue)    *
  ***************************************************************************/
 
-XM((body)(only),  (B), "only print body of tad file.", bool, DL(false, "off"))
+XM((body)(only),  (B), "only print body of tad file.", bool_switch_t, DL(bool_switch_t{false}, "off"))
 XM((fasta), (f), "faidx indexed reference sequence file", std::string, "")
 XM((header), (h), "Location of separate bam header file for read-groups.", 
    std::string, "")
-   XM((header)(only),  (H), "only print header of tad file.", bool, DL(false, "off"))
+XM((header)(only),  (H), "only print header of tad file.", bool_switch_t, DL(bool_switch_t{false}, "off"))
 XM((max)(dp), , "maximum depth", int, 0)
 XM((min)(dp), , "minimum depth", int, 0)
 XM((min)(qlen), (l), "minimum query length", int, 0)

--- a/src/lib/task/call.cc
+++ b/src/lib/task/call.cc
@@ -219,7 +219,8 @@ int process_bam(task::Call::argument_type &arg) {
     // Construct peeling algorithm from parameters and pedigree information
     RelationshipGraph relationship_graph;
     if (!relationship_graph.Construct(ped, mpileup.libraries(), inheritance_model(arg.model),
-                                      arg.mu, arg.mu_somatic, arg.mu_library)) {
+                                      arg.mu, arg.mu_somatic, arg.mu_library,
+                                      arg.normalize_somatic_trees)) {
         throw std::runtime_error("Unable to construct peeler for pedigree; "
                                  "possible non-zero-loop relationship_graph.");
     }
@@ -441,7 +442,8 @@ int process_ad(task::Call::argument_type &arg) {
     // Construct peeling algorithm from parameters and pedigree information
     RelationshipGraph relationship_graph;
     if (!relationship_graph.Construct(ped, mpileup.libraries(), inheritance_model(arg.model),
-                                      arg.mu, arg.mu_somatic, arg.mu_library)) {
+                                      arg.mu, arg.mu_somatic, arg.mu_library,
+                                      arg.normalize_somatic_trees)) {
         throw std::runtime_error("Unable to construct peeler for pedigree; "
                                  "possible non-zero-loop relationship_graph.");
     }
@@ -567,7 +569,8 @@ int process_bcf(task::Call::argument_type &arg) {
 
     dng::RelationshipGraph relationship_graph;
     if (!relationship_graph.Construct(ped, mpileup.libraries(), model,
-                                      arg.mu, arg.mu_somatic, arg.mu_library)) {
+                                      arg.mu, arg.mu_somatic, arg.mu_library,
+                                      arg.normalize_somatic_trees)) {
         throw std::runtime_error("Unable to construct peeler for pedigree; "
                                  "possible non-zero-loop relationship_graph.");
     }

--- a/src/lib/task/loglike.cc
+++ b/src/lib/task/loglike.cc
@@ -157,7 +157,8 @@ int process_bam(LogLike::argument_type &arg) {
     // Construct peeling algorithm from parameters and pedigree information
     RelationshipGraph relationship_graph;
     if (!relationship_graph.Construct(ped, mpileup.libraries(), inheritance_model(arg.model),
-                                      arg.mu, arg.mu_somatic, arg.mu_library)) {
+                                      arg.mu, arg.mu_somatic, arg.mu_library,
+                                      arg.normalize_somatic_trees)) {
         throw std::runtime_error("Unable to construct peeler for pedigree; "
                                  "possible non-zero-loop relationship_graph.");
     }
@@ -266,7 +267,8 @@ int process_ad(LogLike::argument_type &arg) {
     InheritanceModel model = inheritance_model(arg.model);
 
     RelationshipGraph graph;
-    if(!graph.Construct(ped, input.libraries(), model, arg.mu, arg.mu_somatic, arg.mu_library)) {
+    if(!graph.Construct(ped, input.libraries(), model, arg.mu, arg.mu_somatic, arg.mu_library,
+        arg.normalize_somatic_trees)) {
         throw runtime_error("Error: Unable to construct peeler for pedigree; "
                             "possible non-zero-loop pedigree.");
     }


### PR DESCRIPTION
## Simplify how users specify the mutation rate:
* making the default of mu-somatic and mu-library be 0
* scaling somatic trees so that their height is 1 (relative to mu-somatic)
* create option to turn off automatic scaling
* update tests

## Program Options Updates
* create a new program argument type, bool_switch_t, to replace how bool used to be used.
* using a bool in a program argument now create flags that can be turned on and off with arguments
* rearrange xmh files to better manage shared options