### PR TITLE
Add VCF/BCF input support for dng-loglike 

### DIFF
--- a/src/dng.sh.in
+++ b/src/dng.sh.in
@@ -49,7 +49,7 @@ call_command_ex() {
         echo "ERROR: command '$cmd' not recognized"
         return 1
     fi
-    $cmdpath $@
+    exec $cmdpath "$@"
     return $?
 }
 
@@ -59,9 +59,9 @@ call_command() {
 	# check if the command is internal
 	# other wise run external command
     if submatch "$cmd" "$int_cmds"; then
-        dng_$cmd $@
+        dng_$cmd "$@"
     else
-        call_command_ex $@
+        call_command_ex "$@"
     fi
     return $?
 }
@@ -159,6 +159,6 @@ if [ "$#" -eq 0 ]; then
     exit 0
 fi
 
-call_command $@
+call_command "$@"
 
 exit $?

--- a/src/lib/task/call.cc
+++ b/src/lib/task/call.cc
@@ -161,7 +161,7 @@ int task::Call::operator()(Call::argument_type &arg) {
     for(++it; it != arg.input.end(); ++it) {
     	// Make sure different types of input files aren't mixed together
         if(utility::input_category(*it, FileCat::Sequence|FileCat::Pileup|FileCat::Variant, FileCat::Sequence) != mode) {
-            throw std::runtime_error("Mixing pileup, sequencing, and variant file types is not supported.");
+            throw std::invalid_argument("Mixing pileup, sequencing, and variant file types is not supported.");
         }
     }
 
@@ -175,7 +175,7 @@ int task::Call::operator()(Call::argument_type &arg) {
     	// tad, ad
     	return process_ad(arg);
     } else {
-    	throw std::runtime_error("Unknown input data file type.");
+    	throw std::invalid_argument("Unknown input data file type.");
     }
     return EXIT_FAILURE;
 }

--- a/utils/optimize_parameters.R
+++ b/utils/optimize_parameters.R
@@ -1,22 +1,50 @@
 #! Rscript --vanilla
 
 DNGLL_BIN = "dng loglike"
+DNGLL_BIN = "./src/dng-loglike"
 
 # Run dng loglike and extract the log like
-run_once = function(x) {
-
+run_once = function(pars,input) {
+    args = paste("--", names(pars), "=", pars,sep="")
+    out = system2(DNGLL_BIN, args=c(args,input),stdout=TRUE,stderr=FALSE)
+    if(is.numeric(out)) {
+        return(NA)
+    }
+    score = strsplit(tail(out,1),"\t")[[1]][1]
+    -as.numeric(score)
 }
 
-main = function(args) {
+loglike = function(pars,peds,inputs) {
+    total = c()
+    for(i in seq_along(inputs)) {
+        p = c(pars, ped=peds[i])
+        score = run_once(p,inputs[i])
+        total = c(total,score)
+    }
+    print(total)
+    total = sum(total)
+    print(c(total,pars))
 
+    total
 }
 
-# GTEX-13OVK.20170717.vcf
-# GTEX-WOFM.20170717.vcf
-
+main = function(peds,inputs) {
+    pars = make_pars(c(
+        "lib-bias" = 1.01,
+        "lib-error" = 0.0036,
+        "lib-overdisp" = 0.038,
+        "mu-somatic" = 0.00055,
+        "theta" = 0.054,
+        "ref-weight" = 1.01
+    ))
+    o = optim(pars,loglike,peds=peds,inputs=inputs,method="Nelder-Mead",control=list(
+        trace=6,REPORT=1,reltol=1e-4
+    ))
+    o
+}
 
 if(!interactive()) {
     ARGS = commandArgs(trailingOnly=TRUE)
-    data = readLInes(ARGS[1])
-    main(data)
+    data = read.csv(ARGS[1],header=F,stringsAsFactors=FALSE)
+    main(data$V1,data$V2)
 }

--- a/utils/optimize_parameters.R
+++ b/utils/optimize_parameters.R
@@ -6,13 +6,16 @@ registerDoParallel()
 
 DNGLL_BIN = "dng"
 
+fixed_pars = c(
+    "theta" = 0.001
+)
+
 init_pars = c(
         "lib-bias" = 1.009997e+00,
         "lib-error" =  3.200240e-03,
         "lib-overdisp" = 2.526826e-02,
         "mu-somatic" = 3.276369e-04,
-        "theta" = 1,
-        "ref-weight" = 1000
+        "ref-weight" = 1
 )
 
 upper_pars = c(
@@ -35,6 +38,7 @@ lower_pars = c(
 
 # Run dng loglike and extract the log like
 run_once = function(pars,input) {
+    pars = c(pars,fixed_pars)
     args = paste("--", names(pars), "=", pars,sep="")
     if(grepl("dng$",DNGLL_BIN)) {
         args = c("loglike",args)
@@ -52,8 +56,7 @@ loglike = function(pars,peds,inputs) {
     if(any(pars < lower_pars[n] | pars > upper_pars[n])) {
         return(NA)
     }
-    print(pars)
-    pars["ref-weight"] = pars["ref-weight"]*pars["theta"]
+    #print(pars)
     results = foreach(i=seq_along(inputs),.combine=c) %dopar% run_once(c(pars, ped=peds[i]),inputs[i])
     total = sum(results)
     total

--- a/utils/optimize_parameters.R
+++ b/utils/optimize_parameters.R
@@ -1,0 +1,22 @@
+#! Rscript --vanilla
+
+DNGLL_BIN = "dng loglike"
+
+# Run dng loglike and extract the log like
+run_once = function(x) {
+
+}
+
+main = function(args) {
+
+}
+
+# GTEX-13OVK.20170717.vcf
+# GTEX-WOFM.20170717.vcf
+
+
+if(!interactive()) {
+    ARGS = commandArgs(trailingOnly=TRUE)
+    data = readLInes(ARGS[1])
+    main(data)
+}


### PR DESCRIPTION
dng-loglike can now calculate the log-likelihood for VCF/BCF files.

Add a script to the utils directory to support maximum-likelihood optimization of parameters.

Fix parameter handling in `dng` master script to preserve spaces in input arguments.