### PR TITLE
Fix crashes caused by empty pedigrees

### DIFF
--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 ###############################################################################
 # Testdata information
-set(TESTDATA_COMMIT ede868087fab2b9c15ec1ed607f896e605ec999c)
-set(TESTDATA_SHA256 a683dccead08754de14502c56f434049e9023eac2965496571ed406801d7c1f7)
+set(TESTDATA_COMMIT 14ef6584dc86b1e303b60b06e761b3b452aceab3)
+set(TESTDATA_SHA256 41745b0db8bf468697f72853db1ef47a847d0e285808a57c5e6edf57db1a9edb)
 set(TESTDATA_REPO denovogear/testdata)
 set(TESTDATA_URL "https://api.github.com/repos/${TESTDATA_REPO}/tarball/${TESTDATA_COMMIT}")
 set(TESTDATA_DIR "${CMAKE_BINARY_DIR}/testdata")

--- a/Tests/DngCall/BamTest.cmake.in
+++ b/Tests/DngCall/BamTest.cmake.in
@@ -64,7 +64,25 @@ set(SepHeader2-STDOUT
 )
 
 ###############################################################################
+# Test if dng-call crashes on partial pedigree
+
+set(PartialPed-CMD @DNG_CALL_EXE@ --ped duo.ped --fasta trio.fasta.gz trio.bam)
+set(PartialPed-WD "@TESTDATA_DIR@/human_trio/")
+set(PartialPed-RESULT 0)
+set(PartialPed-STDOUT
+  "##PEDIGREE=<ID=LB/NA12878/Solexa-135852,Original=GL/1,OriginalMR=0.0>"
+)
+
+###############################################################################
+# Test if dng-call crashes on empty pedigree
+
+set(EmptyPed-CMD @DNG_CALL_EXE@ --ped empty.ped --fasta trio.fasta.gz trio.bam)
+set(EmptyPed-WD "@TESTDATA_DIR@/human_trio/")
+set(EmptyPed-RESULT 0)
+
+###############################################################################
 # Add Tests
+
 include("@CMAKE_CURRENT_SOURCE_DIR@/CheckProcessTest.cmake")
 
 CheckProcessTests(DngCall.Bam
@@ -74,4 +92,6 @@ CheckProcessTests(DngCall.Bam
   TagID
   SepHeader1
   SepHeader2
+  PartialPed
+  EmptyPed
 )

--- a/Tests/DngCall/CramTest.cmake.in
+++ b/Tests/DngCall/CramTest.cmake.in
@@ -46,12 +46,32 @@ set(TagID-STDOUT
 )
 
 ###############################################################################
+# Test if dng-call crashes on partial pedigree
+
+set(PartialPed-CMD @DNG_CALL_EXE@ --fasta trio.fasta.gz --ped duo.ped trio.cram)
+set(PartialPed-WD "@TESTDATA_DIR@/human_trio/")
+set(PartialPed-RESULT 0)
+set(PartialPed-STDOUT
+  "##PEDIGREE=<ID=LB/NA12878/Solexa-135852,Original=GL/1,OriginalMR=0.0>"
+)
+
+###############################################################################
+# Test if dng-call crashes on empty pedigree
+
+set(EmptyPed-CMD @DNG_CALL_EXE@ --fasta trio.fasta.gz --ped empty.ped trio.cram)
+set(EmptyPed-WD "@TESTDATA_DIR@/human_trio/")
+set(EmptyPed-RESULT 0)
+
+###############################################################################
 # Add Tests
+
 include("@CMAKE_CURRENT_SOURCE_DIR@/CheckProcessTest.cmake")
 
-CheckProcessTests(DngCall.Bam
+CheckProcessTests(DngCall.Cram
   Trio
   TagLB
   TagSM
   TagID
+  PartialPed
+  EmptyPed
 )

--- a/Tests/DngCall/TadTest.cmake.in
+++ b/Tests/DngCall/TadTest.cmake.in
@@ -46,6 +46,29 @@ set(Ceph-STDOUT
   "MUP=0\\.999943\;LLD=-20\\.6508\;LLS=12\\.1871\;MUX=0\\.999997\;MU1P=0\\.999889\;DNT=(GA|GT)>TA\;DNL=LB/NA12891\;DNQ=3\;DP=90\;AD=60,9,21"
 )
 
+###############################################################################
+# Test if dng-call crashes on partial pedigree
+
+set(PartialPed-CMD @DNG_CALL_EXE@ --ped duo.ped trio.tad)
+set(PartialPed-WD "@TESTDATA_DIR@/human_trio/")
+set(PartialPed-RESULT 0)
+set(PartialPed-STDOUT
+  "##PEDIGREE=<ID=LB/NA12878/Solexa-135852,Original=GL/1,OriginalMR=0.0>"
+)
+
+###############################################################################
+# Test if dng-call crashes on empty pedigree
+
+set(EmptyPed-CMD @DNG_CALL_EXE@ --ped empty.ped trio.tad)
+set(EmptyPed-WD "@TESTDATA_DIR@/human_trio/")
+set(EmptyPed-RESULT 0)
+
 include("@CMAKE_CURRENT_SOURCE_DIR@/CheckProcessTest.cmake")
 
-CheckProcessTestS(DngCall.Tad Trio TrioExtraCol Ceph)
+CheckProcessTestS(DngCall.Tad
+  Trio
+  TrioExtraCol
+  Ceph
+  PartialPed
+  EmptyPed
+)

--- a/Tests/DngCall/VcfTest.cmake.in
+++ b/Tests/DngCall/VcfTest.cmake.in
@@ -54,6 +54,33 @@ set(TrioExtraCol-STDOUT
   "0/0:147:1,1\\.99685e-15,0,1\\.99954e-26,0,0:3\\.33278e-05:3\\.33278e-05:0,-18\\.4896,-138\\.087,-21\\.9623,-138\\.388,-141\\.865:77:76,1,0"
 )
 
+###############################################################################
+# Test if dng-call crashes on partial pedigree
+
+set(PartialPed-CMD @DNG_CALL_EXE@ --ped duo.ped trio.vcf)
+set(PartialPed-WD "@TESTDATA_DIR@/human_trio/")
+set(PartialPed-RESULT 0)
+set(PartialPed-STDOUT
+  "##PEDIGREE=<ID=LB/NA12878/Solexa-135852,Original=GL/1,OriginalMR=0.0>"
+)
+
+###############################################################################
+# Test if dng-call crashes on empty pedigree
+
+set(EmptyPed-CMD @DNG_CALL_EXE@ --ped empty.ped trio.vcf)
+set(EmptyPed-WD "@TESTDATA_DIR@/human_trio/")
+set(EmptyPed-RESULT 0)
+
+###############################################################################
+# Add Tests
+
 include("@CMAKE_CURRENT_SOURCE_DIR@/CheckProcessTest.cmake")
 
-CheckProcessTestS(DngCall.Vcf Trio TrioAlt TrioAltRegions TrioExtraCol)
+CheckProcessTests(DngCall.Vcf
+  Trio
+  TrioAlt
+  TrioAltRegions
+  TrioExtraCol
+  PartialPed
+  EmptyPed
+)

--- a/Tests/DngPileup/BamTest.cmake.in
+++ b/Tests/DngPileup/BamTest.cmake.in
@@ -12,7 +12,7 @@ set(TrioTad-RESULT 0)
 # Test unfiltered output vs expected
 
 set(TrioTadBodyCompare_1-CMD @DNG_PILEUP_EXE@ -B -q 0 -Q 0 -f trio.fasta.gz -o ${OUTPUT_DIR}/trio_unfiltered.tad trio.bam)
-set(TrioTadBodyCompare_2-CMD @CMAKE_COMMAND@ -E compare_files trio_unfiltered.tad ${OUTPUT_DIR}/trio_unfiltered.tad)
+set(TrioTadBodyCompare_2-CMD @CMAKE_COMMAND@ -E compare_files trio_unfiltered.tad.body ${OUTPUT_DIR}/trio_unfiltered.tad)
 
 set(TrioTadBodyCompare_1-WD "${All-WD}")
 set(TrioTadBodyCompare_1-RESULT 0)
@@ -32,7 +32,7 @@ set(TrioAd-RESULT 0)
 
 set(TrioAdBodyCompare_1-CMD @DNG_PILEUP_EXE@ -q 0 -Q 0 -f trio.fasta.gz -o ${OUTPUT_DIR}/trio_unfiltered2.ad trio.bam)
 set(TrioAdBodyCompare_2-CMD @DNG_PILEUP_EXE@ -B -o ${OUTPUT_DIR}/trio_unfiltered2.tad ${OUTPUT_DIR}/trio_unfiltered2.ad)
-set(TrioAdBodyCompare_3-CMD @CMAKE_COMMAND@ -E compare_files trio_unfiltered.tad ${OUTPUT_DIR}/trio_unfiltered2.tad)
+set(TrioAdBodyCompare_3-CMD @CMAKE_COMMAND@ -E compare_files trio_unfiltered.tad.body ${OUTPUT_DIR}/trio_unfiltered2.tad)
 
 set(TrioAdBodyCompare_1-WD "${All-WD}")
 set(TrioAdBodyCompare_1-RESULT 0)

--- a/src/include/dng/io/bam.h
+++ b/src/include/dng/io/bam.h
@@ -191,12 +191,6 @@ void BamPileup::operator()(CallBack call_back) {
     location_t current_loc = 0;
     location_t fast_forward_loc = 0;
 
-    // if we have no read_groups specified, use each file as a single group
-    // TODO: check this
-    if(data.empty()) {
-        data.resize(scanners_.size());
-    }
-
     // If the first file has parsed regions, use them.
     std::queue<location_range_t> region_queue;
     for(auto && r : scanners_.front().file().regions()) {
@@ -238,6 +232,7 @@ template<typename R>
 void BamPileup::SelectLibraries(R &range) {
     // Clear all output libraries
     output_libraries_ = {};
+    read_group_to_libraries_.clear();
 
     // For every library in range, try to find it in input_libraries_
     size_t k=0;

--- a/src/include/dng/io/bcf.h
+++ b/src/include/dng/io/bcf.h
@@ -197,8 +197,14 @@ void BcfPileup::SelectLibraries(R &range) {
         }
         selector += bcf_samples_[pos];
     }
-    if(bcf_hdr_set_samples(reader_.reader(0)->header, selector.c_str(),0) != 0) {
-        throw std::runtime_error("Unable to select VCF/BCF columns '" + selector + "'." );
+    if(selector.empty()) {
+        if(bcf_hdr_set_samples(reader_.reader(0)->header,nullptr,0) != 0) {
+            throw std::runtime_error("Unable to exclude all VCF/BCF columns." );
+        }
+    } else {
+        if(bcf_hdr_set_samples(reader_.reader(0)->header, selector.c_str(),0) != 0) {
+            throw std::runtime_error("Unable to select VCF/BCF columns '" + selector + "'." );
+        }
     }
 }
 


### PR DESCRIPTION
`dng::io::BamPileup::SelectLibraries` forgets to clear the ` read_group_to_libraries_` map, resulting in invalid or out-of-date indexes being returned to connect read-groups to libraries.

`dng::io::BamPileup` now requires RG information for reads, which means that specifying one file per read-group is no longer supported. This feature had not been well maintained or supported through version, so I am retiring it.

`dng::io::VcfPileup::SelectLibraries` now passes `nullptr` to `bcf_hdr_set_samples` to remove all samples from the input. This prevents a cryptic error message.

Tests were added to DngCall to verify that the crashes are fixed. This requires an update of TESTDATA information.