### PR TITLE
Fixed issue 209, dng-loglike segfaults on bam

### DIFF
--- a/src/lib/task/call.cc
+++ b/src/lib/task/call.cc
@@ -187,7 +187,7 @@ int process_bam(task::Call::argument_type &arg) {
 
     // Open Reference
     if(arg.fasta.empty()){
-    	throw std::runtime_error("Path to fasta file is empty.");
+    	throw std::invalid_argument("Path to reference file must be specified with --fasta when processing bam/sam/cram files.");
     }
     io::Fasta reference{arg.fasta.c_str()};
 

--- a/src/lib/task/call.cc
+++ b/src/lib/task/call.cc
@@ -186,6 +186,9 @@ int process_bam(task::Call::argument_type &arg) {
     Pedigree ped = io::parse_ped(arg.ped);
 
     // Open Reference
+    if(arg.fasta.empty()){
+    	throw std::runtime_error("Path to fasta file is empty.");
+    }
     io::Fasta reference{arg.fasta.c_str()};
 
     // Parse Nucleotide Frequencies

--- a/src/lib/task/loglike.cc
+++ b/src/lib/task/loglike.cc
@@ -133,8 +133,9 @@ int process_bam(LogLike::argument_type &arg) {
     Pedigree ped = io::parse_ped(arg.ped);
 
     // Open Reference
-    if(arg.fasta.empty())
+    if(arg.fasta.empty()){
     	throw std::runtime_error("Path to fasta file is empty.");
+    }
     io::Fasta reference{arg.fasta.c_str()};
 
     // Parse Nucleotide Frequencies

--- a/src/lib/task/loglike.cc
+++ b/src/lib/task/loglike.cc
@@ -133,6 +133,8 @@ int process_bam(LogLike::argument_type &arg) {
     Pedigree ped = io::parse_ped(arg.ped);
 
     // Open Reference
+    if(arg.fasta.empty())
+    	throw std::runtime_error("Path to fasta file is empty.");
     io::Fasta reference{arg.fasta.c_str()};
 
     // Parse Nucleotide Frequencies

--- a/src/lib/task/loglike.cc
+++ b/src/lib/task/loglike.cc
@@ -134,7 +134,7 @@ int process_bam(LogLike::argument_type &arg) {
 
     // Open Reference
     if(arg.fasta.empty()){
-    	throw std::runtime_error("Path to fasta file is empty.");
+    	throw std::invalid_argument("Path to reference file must be specified with --fasta when processing bam/sam/cram files.");
     }
     io::Fasta reference{arg.fasta.c_str()};
 

--- a/src/lib/task/pileup.cc
+++ b/src/lib/task/pileup.cc
@@ -80,6 +80,9 @@ int process_bam(Pileup::argument_type &arg) {
     using dng::io::BamPileup;
 
     // Open Reference
+    if(arg.fasta.empty()){
+    	throw std::runtime_error("Path to fasta file is empty.");
+    }
     io::Fasta reference{arg.fasta.c_str()};
 
     // Open input files

--- a/src/lib/task/pileup.cc
+++ b/src/lib/task/pileup.cc
@@ -81,7 +81,7 @@ int process_bam(Pileup::argument_type &arg) {
 
     // Open Reference
     if(arg.fasta.empty()){
-    	throw std::runtime_error("Path to fasta file is empty.");
+    	throw std::invalid_argument("Path to reference file must be specified with --fasta when processing bam/sam/cram files.");
     }
     io::Fasta reference{arg.fasta.c_str()};
 


### PR DESCRIPTION
The segmentation fault message was thrown because dng-loglike requires a fasta file as input, along with a ped and a sam/bam file. Check has been added to assure a fasta file is given.