### PR TITLE
Fix the construction of haploid priors

### DIFF
--- a/src/include/dng/probability.h
+++ b/src/include/dng/probability.h
@@ -59,6 +59,9 @@ protected:
 
     matrices_t CreateMutationMatrices(const int mutype = MUTATIONS_ALL) const;
 
+    GenotypeArray DiploidPrior(int ref_index, int color);
+    GenotypeArray HaploidPrior(int ref_index, int color);
+
     RelationshipGraph graph_;
     params_t params_;
     peel::workspace_t work_; // must be declared after graph_ (see constructor)
@@ -92,6 +95,30 @@ LogProbability::matrices_t LogProbability::CreateMutationMatrices(const int muty
         ret[color] = create_mutation_matrices_subset(full_matrix, color);
     }
     return ret;
+}
+
+inline
+GenotypeArray LogProbability::DiploidPrior(int ref_index, int color) {
+    using AlleleDepths = dng::pileup::AlleleDepths;
+    auto &type_info = AlleleDepths::type_info_gt_table[color];
+    const int width = type_info.width;
+    GenotypeArray prior(width);
+    for(int i=0;i<width;++i) {
+        prior(i) = diploid_prior_[ref_index](type_info.indexes[i]);
+    }
+    return prior;
+}
+
+inline
+GenotypeArray LogProbability::HaploidPrior(int ref_index, int color) {
+    using AlleleDepths = dng::pileup::AlleleDepths;
+    auto &type_info = AlleleDepths::type_info_table[color];
+    const int width = type_info.width;
+    GenotypeArray prior(width);
+    for(int i=0;i<width;++i) {
+        prior(i) = haploid_prior_[ref_index](type_info.indexes[i]);
+    }
+    return prior;
 }
 
 }; // namespace dng

--- a/src/lib/call_mutations.cc
+++ b/src/lib/call_mutations.cc
@@ -71,20 +71,12 @@ bool CallMutations::operator()(const pileup::RawDepths &depths,
 
 bool CallMutations::operator()(const pileup::AlleleDepths &depths,
                 stats_t *stats) {
-    int ref_index = depths.type_info().reference;
-    size_t gt_width = depths.type_gt_info().width;
-    size_t width = depths.type_info().width;
-    // Set the prior probability of the founders given the reference
-    GenotypeArray diploid_prior(gt_width);
-    for(int i=0;i<gt_width;++i) {
-        diploid_prior(i) = diploid_prior_[ref_index](depths.type_gt_info().indexes[i]);
-    }
-    GenotypeArray haploid_prior(width);
-    for(int i=0;i<width;++i) {
-        haploid_prior(i) = diploid_prior_[ref_index](0);//depths.type_info().indexes[i]);
-    }
+    const int ref_index = depths.type_info().reference;
+    const int color = depths.color();
     
     // Set the prior probability of the founders given the reference
+    GenotypeArray diploid_prior = DiploidPrior(ref_index, color);
+    GenotypeArray haploid_prior = HaploidPrior(ref_index, color);
     work_.SetFounders(diploid_prior, haploid_prior);
 
     // Genotype Likelihoods

--- a/src/lib/probability.cc
+++ b/src/lib/probability.cc
@@ -89,8 +89,8 @@ LogProbability::value_t LogProbability::operator()(const pileup::RawDepths &dept
 // Calculate the probability of a depths object considering only indexes
 // TODO: make indexes a property of the pedigree
 LogProbability::value_t LogProbability::operator()(const pileup::AlleleDepths &depths) {
-    int ref_index = depths.type_info().reference;
-    int color = depths.color();
+    const int ref_index = depths.type_info().reference;
+    const int color = depths.color();
 
     double scale, logdata;
     // For monomorphic sites we have pre-calculated the peeling part
@@ -107,20 +107,10 @@ LogProbability::value_t LogProbability::operator()(const pileup::AlleleDepths &d
         }
         // convert to a log-likelihood
         logdata = log(logdata);
-    } else {
-        size_t gt_width = depths.type_gt_info().width;
-        size_t width = depths.type_info().width;
+    } else {      
         // Set the prior probability of the founders given the reference
-        GenotypeArray diploid_prior(gt_width);
-        for(int i=0;i<gt_width;++i) {
-            diploid_prior(i) = diploid_prior_[ref_index](depths.type_gt_info().indexes[i]);
-        }
-        GenotypeArray haploid_prior(width);
-        for(int i=0;i<width;++i) {
-            haploid_prior(i) = diploid_prior_[ref_index](depths.type_info().indexes[i]);
-        }
-
-        // Set founders
+        GenotypeArray diploid_prior = DiploidPrior(ref_index, color);
+        GenotypeArray haploid_prior = HaploidPrior(ref_index, color);
         work_.SetFounders(diploid_prior, haploid_prior);
   
         // Calculate genotype likelihoods


### PR DESCRIPTION
Use `LogProbability::haploid_prior_` to construct haploid priors in `LogProbability` and `CallMutation`