### PR TITLE
Improved check for HTSLIB version on Unit test

### DIFF
--- a/Tests/Unit/CMakeLists.txt
+++ b/Tests/Unit/CMakeLists.txt
@@ -50,6 +50,7 @@ AddUnitTest(dng::relationship_graph)
 AddUnitTest(dng::seq)
 AddUnitTest(dng::stats)
 AddUnitTest(dng::utility)
+AddUnitTest(hts::hts)
 
 # These tests are broken by changes to the library
 # disable them for now so we can merge important changes

--- a/Tests/Unit/hts/hts.cc
+++ b/Tests/Unit/hts/hts.cc
@@ -24,14 +24,13 @@
 #include "../testing.h"
 
 #include <fstream>
-#include <string>
 
 using namespace hts;
 using hts::version_parse;
 
 BOOST_AUTO_TEST_CASE(test_hts_version) {
-    auto test = [](const char* version_char, unsigned long version_int) ->  void {    
-    BOOST_TEST_CONTEXT("version_string='" << std::string(version_char) << "'"){
+    auto test = [](const char* version_char, unsigned long version_int) ->  void {
+    BOOST_TEST_CONTEXT("version_string='" << version_char << "'"){
 	auto result = version_parse(version_char);
 	BOOST_CHECK_EQUAL(result, version_int);
     }};

--- a/Tests/Unit/hts/hts.cc
+++ b/Tests/Unit/hts/hts.cc
@@ -27,8 +27,8 @@ using namespace hts;
 using hts::version_parse;
 
 BOOST_AUTO_TEST_CASE(test_hts_version) {
-    auto test = [](const char* version_char, unsigned long version_int) ->  void {
-    BOOST_TEST_CONTEXT("version_string='" << version_char << "'"){
+    auto test = [](const char* version_char, unsigned long version_int) ->  void {    
+    BOOST_TEST_CONTEXT("version_string='" << std::string(version_char) << "'"){
 	auto result = version_parse(version_char);
 	BOOST_CHECK_EQUAL(result, version_int);
     }};

--- a/Tests/Unit/hts/hts.cc
+++ b/Tests/Unit/hts/hts.cc
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2017 Reed A. Cartwright
+ * Authors:  Reed A. Cartwright <reed@cartwrig.ht>
+ *	     Juan J. Garcia Mesa <jgarc111@asu.edu>
+ *
+ * This file is part of DeNovoGear.
+ *
+ * DeNovoGear is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define BOOST_TEST_MODULE hts::hts
+
+#include <dng/hts/hts.h>
+#include "../testing.h"
+
+using namespace hts;
+using hts::version_parse;
+
+BOOST_AUTO_TEST_CASE(test_hts_version) {
+    auto test = [](const char* version_char, unsigned long version_int) ->  void {
+    BOOST_TEST_CONTEXT("version_string='" << version_char << "'"){
+	auto result = version_parse(version_char);
+	BOOST_CHECK_EQUAL(result, version_int);
+    }};
+
+    test("1.5-16-g7cdd574",10516);
+    test("1.4.1",10401);
+    test("1.4",10400);
+    test("001.4.01",10401);
+    test("1.4-1",10401);
+    test("0",0);
+}
+
+BOOST_AUTO_TEST_CASE(test_fail_hts_version,
+    * boost::unit_test::expected_failures(5)) {
+    auto test_fail = [](const char* version_char, unsigned long version_int) -> void {
+    BOOST_TEST_CONTEXT("version_char='" << version_char << "'"){
+	auto result = version_parse(version_char);
+	BOOST_CHECK_EQUAL(result, version_int);
+    }};
+
+    test_fail("htslib version 1.5",10500);
+    test_fail("1.5",10000);
+    test_fail(".1.4.1",10401);
+    test_fail("1..5",10500);
+    //check empty char
+    test_fail("",10000);
+}

--- a/Tests/Unit/hts/hts.cc
+++ b/Tests/Unit/hts/hts.cc
@@ -39,20 +39,8 @@ BOOST_AUTO_TEST_CASE(test_hts_version) {
     test("001.4.01",10401);
     test("1.4-1",10401);
     test("0",0);
-}
-
-BOOST_AUTO_TEST_CASE(test_fail_hts_version,
-    * boost::unit_test::expected_failures(5)) {
-    auto test_fail = [](const char* version_char, unsigned long version_int) -> void {
-    BOOST_TEST_CONTEXT("version_char='" << version_char << "'"){
-	auto result = version_parse(version_char);
-	BOOST_CHECK_EQUAL(result, version_int);
-    }};
-
-    test_fail("htslib version 1.5",10500);
-    test_fail("1.5",10000);
-    test_fail(".1.4.1",10401);
-    test_fail("1..5",10500);
-    //check empty char
-    test_fail("",10000);
+    test("htslib version 1.5",0);
+    test("1,5",0);
+    test("1 . 4",0);
+    test(" ",0);
 }

--- a/Tests/Unit/hts/hts.cc
+++ b/Tests/Unit/hts/hts.cc
@@ -23,6 +23,9 @@
 #include <dng/hts/hts.h>
 #include "../testing.h"
 
+#include <fstream>
+#include <string>
+
 using namespace hts;
 using hts::version_parse;
 

--- a/Tests/Unit/testing.h
+++ b/Tests/Unit/testing.h
@@ -25,7 +25,7 @@
 #include <type_traits>
 #include <boost/test/unit_test.hpp>
 #include <boost/preprocessor/seq/for_each.hpp>
-
+#include <boost/version.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/fstream.hpp>
 #include <boost/range/size.hpp>
@@ -93,10 +93,11 @@
     } while(false) \
 /**/
 
-
+#ifndef BOOST_TEST_CONTEXT
 #define BOOST_TEST_CONTEXT(D) \
     if(true) \
 /**/
+#endif
 
 #ifndef BOOST_TEST_INFO
 #define BOOST_TEST_INFO(D) \

--- a/Tests/Unit/testing.h
+++ b/Tests/Unit/testing.h
@@ -94,11 +94,9 @@
 /**/
 
 
-#ifndef BOOST_TEST_CONTEXT
 #define BOOST_TEST_CONTEXT(D) \
     if(true) \
 /**/
-#endif
 
 #ifndef BOOST_TEST_INFO
 #define BOOST_TEST_INFO(D) \

--- a/src/include/dng/hts/hts.h
+++ b/src/include/dng/hts/hts.h
@@ -85,7 +85,7 @@ unsigned long version() {
         if(!*end) {
             break;
         }
-        if(*end != '.') {
+        if(*end != '.' && *end != '-') {
             return 0; // unexpected format
         }
         str = end+1;

--- a/src/include/dng/hts/hts.h
+++ b/src/include/dng/hts/hts.h
@@ -25,6 +25,8 @@
 #include <memory>
 #include <cassert>
 #include <cstring>
+#include <string>
+#include <sstream>
 
 namespace hts {
 

--- a/src/include/dng/hts/hts.h
+++ b/src/include/dng/hts/hts.h
@@ -76,9 +76,8 @@ private:
 
 // convert hts version string to a numeric value
 inline
-unsigned long version() {
+unsigned long version_parse(const char *str) {
     unsigned long v[3] = {0,0,0};
-    const char *str = hts_version();
     char *end;
     for(int i=0;i<3;++i) {
         v[i] = std::strtoul(str, &end, 10);
@@ -91,6 +90,10 @@ unsigned long version() {
         str = end+1;
     }
     return v[0]*100*100+v[1]*100+v[2];
+}
+
+inline unsigned long version() {
+    return version_parse(hts_version());
 }
 
 };


### PR DESCRIPTION
Now handling char `-` on the conversion of hts version from string to numeric value. Mostly found when HTSLIB is built from a Git repository.
Fixes #237 .