### PR TITLE
Handle BCF missing data in AD field

### DIFF
--- a/src/lib/task/call.cc
+++ b/src/lib/task/call.cc
@@ -23,7 +23,6 @@
 
 #include <cstdlib>
 #include <fstream>
-
 #include <iostream>
 #include <iomanip>
 #include <ctime>
@@ -63,6 +62,10 @@ using namespace dng;
 int process_bam(task::Call::argument_type &arg);
 int process_bcf(task::Call::argument_type &arg);
 int process_ad(task::Call::argument_type &arg);
+
+bool is_positive(int i){
+	return (i<0);
+}
 
 void add_stats_to_output(const CallMutations::stats_t& call_stats, const pileup::stats_t& depth_stats,
     bool has_single_mut,
@@ -673,12 +676,12 @@ int process_bcf(task::Call::argument_type &arg) {
                 data(i,a) = ad[offset+allele_list[a]];
             }
         }
-
+        //Replace missing data with 0
+        std::replace_if(data.data().begin(),data.data().end() , is_positive, 0);
         if(!do_call(data, &stats)) {
             return;
         }
         const bool has_single_mut = ((stats.mu1p / stats.mup) >= min_prob);
-
         // Measure total depth and sort nucleotides in descending order
         pileup::stats_t depth_stats;
         pileup::calculate_stats(data, &depth_stats);

--- a/src/lib/task/call.cc
+++ b/src/lib/task/call.cc
@@ -23,6 +23,7 @@
 
 #include <cstdlib>
 #include <fstream>
+
 #include <iostream>
 #include <iomanip>
 #include <ctime>
@@ -63,10 +64,6 @@ using namespace dng;
 int process_bam(task::Call::argument_type &arg);
 int process_bcf(task::Call::argument_type &arg);
 int process_ad(task::Call::argument_type &arg);
-
-bool is_missing_data(int i){
-    return (i==hts::bcf::int32_missing);
-}
 
 void add_stats_to_output(const CallMutations::stats_t& call_stats, const pileup::stats_t& depth_stats,
     bool has_single_mut,

--- a/src/lib/task/call.cc
+++ b/src/lib/task/call.cc
@@ -33,6 +33,7 @@
 #include <boost/range/algorithm/replace.hpp>
 #include <boost/range/algorithm/max_element.hpp>
 #include <boost/range/algorithm/fill.hpp>
+#include <boost/range/algorithm/replace_if.hpp>
 
 #include <boost/algorithm/string.hpp>
 
@@ -677,7 +678,7 @@ int process_bcf(task::Call::argument_type &arg) {
             }
         }
         // Replace missing data with 0
-        std::replace_if(data.data().begin(),data.data().end() , is_missing_data, 0);
+        boost::range::replace_if(data.data(), [](int n) {return n==hts::bcf::int32_missing;}, 0);
         if(!do_call(data, &stats)) {
             return;
         }

--- a/src/lib/task/call.cc
+++ b/src/lib/task/call.cc
@@ -63,8 +63,8 @@ int process_bam(task::Call::argument_type &arg);
 int process_bcf(task::Call::argument_type &arg);
 int process_ad(task::Call::argument_type &arg);
 
-bool is_positive(int i){
-	return (i<0);
+bool is_missing_data(int i){
+    return (i==hts::bcf::int32_missing);
 }
 
 void add_stats_to_output(const CallMutations::stats_t& call_stats, const pileup::stats_t& depth_stats,
@@ -676,8 +676,8 @@ int process_bcf(task::Call::argument_type &arg) {
                 data(i,a) = ad[offset+allele_list[a]];
             }
         }
-        //Replace missing data with 0
-        std::replace_if(data.data().begin(),data.data().end() , is_positive, 0);
+        // Replace missing data with 0
+        std::replace_if(data.data().begin(),data.data().end() , is_missing_data, 0);
         if(!do_call(data, &stats)) {
             return;
         }

--- a/src/lib/task/loglike.cc
+++ b/src/lib/task/loglike.cc
@@ -68,6 +68,10 @@ using namespace std;
 using namespace dng;
 using namespace dng::task;
 
+bool is_missing_data(int i){
+    return (i==hts::bcf::int32_missing);
+}
+
 // Helper function for writing the vcf header information
 void cout_add_header_text(task::LogLike::argument_type &arg) {
     using namespace std;
@@ -515,6 +519,9 @@ int process_bcf(LogLike::argument_type &arg) {
                 data(i,a) = ad[offset+allele_list[a]];
             }
         }
+
+	// Replace missing data with 0
+	std::replace_if(data.data().begin(), data.data().end(), is_missing_data, 0);	
 
         auto loglike = calculate(data);
         sum_data += loglike.log_data;

--- a/src/lib/task/loglike.cc
+++ b/src/lib/task/loglike.cc
@@ -69,10 +69,6 @@ using namespace std;
 using namespace dng;
 using namespace dng::task;
 
-bool is_missing_data(int i){
-    return (i==hts::bcf::int32_missing);
-}
-
 // Helper function for writing the vcf header information
 void cout_add_header_text(task::LogLike::argument_type &arg) {
     using namespace std;

--- a/src/lib/task/loglike.cc
+++ b/src/lib/task/loglike.cc
@@ -39,6 +39,7 @@
 #include <boost/range/iterator_range.hpp>
 #include <boost/range/algorithm/replace.hpp>
 #include <boost/range/algorithm/max_element.hpp>
+#include <boost/range/algorithm/replace_if.hpp>
 
 #include <boost/algorithm/string.hpp>
 
@@ -520,8 +521,8 @@ int process_bcf(LogLike::argument_type &arg) {
             }
         }
 
-	// Replace missing data with 0
-	std::replace_if(data.data().begin(), data.data().end(), is_missing_data, 0);	
+        // Replace missing data with 0
+        boost::range::replace_if(data.data(), [](int n) {return n==hts::bcf::int32_missing;}, 0);
 
         auto loglike = calculate(data);
         sum_data += loglike.log_data;


### PR DESCRIPTION
In `call` and `loglike`, if missing data value is found in AD field of BCF file format, it is now replaced with `0` so data is handled properly.
Fixes #235 