### PR TITLE
Initialize All Germline Nodes and add Test Cases

### DIFF
--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 ###############################################################################
 # Testdata information
-set(TESTDATA_COMMIT 18b7020400bfcf0315f3826946a8ae9decb8a6cd)
-set(TESTDATA_SHA256 274372299180d6ffca7fe32904954dab8426b4881112a32945c22e0180040612)
+set(TESTDATA_COMMIT b21878522bf65c335d2688aaa6b23f6fea4d53c7)
+set(TESTDATA_SHA256 208462b692f626443cbcfec2ca04f62b711c6807d2c43f8a78600f32cf9e7414)
 set(TESTDATA_REPO denovogear/testdata)
 set(TESTDATA_URL "https://api.github.com/repos/${TESTDATA_REPO}/tarball/${TESTDATA_COMMIT}")
 set(TESTDATA_DIR "${CMAKE_BINARY_DIR}/testdata")

--- a/Tests/DngCall/VcfTest.cmake.in
+++ b/Tests/DngCall/VcfTest.cmake.in
@@ -64,6 +64,17 @@ set(PartialPed-STDOUT
   "##PEDIGREE=<ID=LB/NA12878/Solexa-135852,Original=GL/1,OriginalMR=0.0>"
 )
 
+set(PartialPed2-CMD @DNG_CALL_EXE@ -m 0 --ped trio.ped duo.vcf)
+set(PartialPed2-WD "@TESTDATA_DIR@/human_trio/")
+set(PartialPed2-RESULT 0)
+set(PartialPed2-STDOUT
+  "##PEDIGREE=<ID=LB/NA12878,Father=GL/NA12891,Mother=GL/NA12892,FatherMR=10.0e-09,MotherMR=10.0e-09>"
+  "##PEDIGREE=<ID=LB/NA12892,Original=GL/NA12892,OriginalMR=0.0>"
+)
+set(PartialPed2-STDOUT-FAIL
+  "##PEDIGREE=<ID=LB/NA12891,Original=GL/NA12891,OriginalMR=0.0>"
+)
+
 ###############################################################################
 # Test if dng-call crashes on empty pedigree
 
@@ -104,6 +115,7 @@ CheckProcessTests(DngCall.Vcf
   TrioAltRegions
   TrioExtraCol
   PartialPed
+  PartialPed2
   EmptyPed
   MissingData
 )

--- a/Tests/Unit/dng/peel.cc
+++ b/Tests/Unit/dng/peel.cc
@@ -62,12 +62,12 @@ BOOST_AUTO_TEST_CASE(test_peel_workspace) {
     work.ploidies.assign(8,2);
     work.ploidies[1] = 1;
 
-    // SetFounders
+    // SetGermline
     GenotypeArray haploid_prior(4), diploid_prior(10);
     generate(make_test_range(haploid_prior), [&](){ return xrand.get_double52(); });
     generate(make_test_range(diploid_prior), [&](){ return xrand.get_double52(); });
 
-    work.SetFounders(diploid_prior, haploid_prior);
+    work.SetGermline(diploid_prior, haploid_prior);
     
     auto test_upper0 = make_test_range(work.upper[0]);
     auto expected_upper0 = make_test_range(diploid_prior);
@@ -87,7 +87,8 @@ BOOST_AUTO_TEST_CASE(test_peel_workspace) {
     for(int i=0;i<work.somatic_nodes.second;++i) {
         BOOST_TEST_INFO("node=" << i);
         auto test_range = make_test_range(work.lower[i]);
-        std::vector<double> expected_range(10,1); 
+        size_t sz = (i == 1) ? 4 : 10;
+        std::vector<double> expected_range(sz,1); 
         CHECK_EQUAL_RANGES(test_range, expected_range);
     }
     for(int i=work.library_nodes.first;i<work.num_nodes;++i) {
@@ -107,7 +108,8 @@ BOOST_AUTO_TEST_CASE(test_peel_workspace) {
     for(int i=0;i<work.num_nodes;++i) {
         BOOST_TEST_INFO("node=" << i);
         auto test_range = make_test_range(work.lower[i]);
-        std::vector<double> expected_range(10,1); 
+        size_t sz = (i == 1) ? 4 : 10;
+        std::vector<double> expected_range(sz,1); 
         CHECK_EQUAL_RANGES(test_range, expected_range);
     }
 }

--- a/Tests/Unit/dng/peel.cc
+++ b/Tests/Unit/dng/peel.cc
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016 Steven H. Wu
- * Copyright (c) 2016 Reed A. Cartwright
+ * Copyright (c) 2016,2017 Reed A. Cartwright
  * Authors:  Steven H. Wu <stevenwu@asu.edu>
  *           Reed A. Cartwright <reed@cartwrig.ht>
  *
@@ -53,16 +53,16 @@ BOOST_AUTO_TEST_CASE(test_peel_workspace) {
     xorshift64 xrand(++g_seed_counter);
 
     workspace_t work;
-    work.Resize(8);
+    work.Resize(10);
     work.founder_nodes = {0,2};
-    work.germline_nodes = {2,3};
-    work.somatic_nodes = {3,4};
-    work.library_nodes = {4,8};
+    work.germline_nodes = {2,4};
+    work.somatic_nodes = {4,5};
+    work.library_nodes = {5,10};
 
-    work.ploidies.assign(8,2);
+    work.ploidies.assign(10,2);
     work.ploidies[1] = 1;
     work.ploidies[2] = 1;
-    work.ploidies[3] = 1;
+    work.ploidies[4] = 1;
 
     // SetGermline
     GenotypeArray haploid_prior(4), diploid_prior(10);

--- a/Tests/Unit/dng/peel.cc
+++ b/Tests/Unit/dng/peel.cc
@@ -61,6 +61,8 @@ BOOST_AUTO_TEST_CASE(test_peel_workspace) {
 
     work.ploidies.assign(8,2);
     work.ploidies[1] = 1;
+    work.ploidies[2] = 1;
+    work.ploidies[3] = 1;
 
     // SetGermline
     GenotypeArray haploid_prior(4), diploid_prior(10);
@@ -87,7 +89,7 @@ BOOST_AUTO_TEST_CASE(test_peel_workspace) {
     for(int i=0;i<work.somatic_nodes.second;++i) {
         BOOST_TEST_INFO("node=" << i);
         auto test_range = make_test_range(work.lower[i]);
-        size_t sz = (i == 1) ? 4 : 10;
+        size_t sz = (i == 1 || i == 2) ? 4 : 10;
         std::vector<double> expected_range(sz,1); 
         CHECK_EQUAL_RANGES(test_range, expected_range);
     }
@@ -108,7 +110,7 @@ BOOST_AUTO_TEST_CASE(test_peel_workspace) {
     for(int i=0;i<work.num_nodes;++i) {
         BOOST_TEST_INFO("node=" << i);
         auto test_range = make_test_range(work.lower[i]);
-        size_t sz = (i == 1) ? 4 : 10;
+        size_t sz = (i == 1 || i == 2) ? 4 : 10;
         std::vector<double> expected_range(sz,1); 
         CHECK_EQUAL_RANGES(test_range, expected_range);
     }

--- a/doc/Developer.md
+++ b/doc/Developer.md
@@ -4,7 +4,7 @@
 
 ```bash
 mkdir ./build/clangdebug
-CXX=clang++ CC=clang cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug
+CXX=clang++ CC=clang cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug ../..
 ninja
 ninja test
 ```
@@ -13,7 +13,7 @@ ninja test
 
 ```bash
 mkdir ./build/coverage
-CXX=g++ CC=gcc cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DDNG_DEVEL_ENABLE_COVERAGE_REPORT=1
+CXX=g++ CC=gcc cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DDNG_DEVEL_ENABLE_COVERAGE_REPORT=1 ../..
 ninja
 ```
 ### Run Unit Tests only

--- a/src/include/dng/matrix.h
+++ b/src/include/dng/matrix.h
@@ -39,8 +39,6 @@ typedef std::vector<GenotypeArray, Eigen::aligned_allocator<GenotypeArray>>
         GenotypeArrayVector;
 
 #define DNG_INDIVIDUAL_BUFFER_MIN DBL_MIN
-#define DNG_INDIVIDUAL_BUFFER_ONES GenotypeArrayVector::value_type::Ones(10)
-#define DNG_INDIVIDUAL_BUFFER_ZEROS GenotypeArrayVector::value_type::Zero(10)
 
 typedef Eigen::MatrixXd TransitionMatrix; // element (i,j) is the P(j|i)
 typedef std::vector<TransitionMatrix> TransitionMatrixVector;

--- a/src/include/dng/peeling.h
+++ b/src/include/dng/peeling.h
@@ -107,24 +107,22 @@ struct workspace_t {
         
         // Set the Upper and Lowers of the Founder Nodes
         for(auto i = founder_nodes.first; i < founder_nodes.second; ++i) {
+            assert(ploidies[i] == 2 || ploidies[i] == 1);
             if(ploidies[i] == 2) {
                 upper[i] = diploid_prior;
                 lower[i].setOnes(diploid_prior.size());
-            } else if(ploidies[i] == 1) {
+            } else {
                 upper[i] = haploid_prior;
                 lower[i].setOnes(haploid_prior.size());  
-            } else {
-                assert(false); // should not be here
             }
         }
         // Also set the lowers of any germline node
         for(auto i = founder_nodes.second; i < germline_nodes.second; ++i) {
+            assert(ploidies[i] == 2 || ploidies[i] == 1);
              if(ploidies[i] == 2) {
                 lower[i].setOnes(diploid_prior.size());
-            } else if(ploidies[i] == 1) {
-                lower[i].setOnes(haploid_prior.size());  
             } else {
-                assert(false); // should not be here
+                lower[i].setOnes(haploid_prior.size());  
             }           
         }
     }

--- a/src/lib/call_mutations.cc
+++ b/src/lib/call_mutations.cc
@@ -54,11 +54,12 @@ CallMutations::CallMutations(double min_prob, const RelationshipGraph &graph, pa
 // Returns true if a mutation was found and the record was modified
 bool CallMutations::operator()(const pileup::RawDepths &depths,
         int ref_index, stats_t *stats) {
-    // Genotype Likelihoods
-    double scale = work_.SetGenotypeLikelihoods(genotyper_, depths, ref_index);
 
     // Set the prior probability of the founders given the reference
-    work_.SetFounders(diploid_prior_[ref_index], haploid_prior_[ref_index]);
+    work_.SetGermline(diploid_prior_[ref_index], haploid_prior_[ref_index]);
+
+    // Genotype Likelihoods
+    double scale = work_.SetGenotypeLikelihoods(genotyper_, depths, ref_index);
 
     // Run
     bool found = Calculate(stats, COLOR_ACGT);
@@ -77,7 +78,7 @@ bool CallMutations::operator()(const pileup::AlleleDepths &depths,
     // Set the prior probability of the founders given the reference
     GenotypeArray diploid_prior = DiploidPrior(ref_index, color);
     GenotypeArray haploid_prior = HaploidPrior(ref_index, color);
-    work_.SetFounders(diploid_prior, haploid_prior);
+    work_.SetGermline(diploid_prior, haploid_prior);
 
     // Genotype Likelihoods
     double scale = work_.SetGenotypeLikelihoods(genotyper_, depths);

--- a/src/lib/probability.cc
+++ b/src/lib/probability.cc
@@ -137,10 +137,10 @@ TransitionMatrixVector dng::create_mutation_matrices(const RelationshipGraph &gr
         } else if(trans.type == RelationshipGraph::TransitionType::Pair) {
             auto orig = f81::matrix(trans.length1, nuc_freq);
             if(graph.ploidy(child) == 1) {
-            	matrices[child] = gamete_matrix(graph.ploidy(trans.parent1), orig, mutype);
+                matrices[child] = gamete_matrix(graph.ploidy(trans.parent1), orig, mutype);
             } else {
-	            assert(graph.ploidy(child) == 2);
-            	matrices[child] = mitosis_matrix(graph.ploidy(trans.parent1), orig, mutype);
+                assert(graph.ploidy(child) == 2);
+                matrices[child] = mitosis_matrix(graph.ploidy(trans.parent1), orig, mutype);
             }
         } else {
             matrices[child] = {};
@@ -154,7 +154,7 @@ TransitionMatrix subset_mutation_matrix_meiosis_autosomal(const TransitionMatrix
 
     const int width = type_info_gt_table[color].width;
 
-	TransitionMatrix ret{width*width, width};
+    TransitionMatrix ret{width*width, width};
 
     // a: parent1/dad; b: parent2/mom;
     // kronecker product is 'a-major'
@@ -185,7 +185,7 @@ TransitionMatrix subset_mutation_matrix_meiosis_xlinked(const TransitionMatrix &
     const int widthA = type_info_table[color].width;                      
     const int widthB = type_info_gt_table[color].width;
 
-	TransitionMatrix ret{widthA*widthB,widthB};
+    TransitionMatrix ret{widthA*widthB,widthB};
 
     for(int a = 0; a < widthA; ++a) {
         const int ga = type_info_table[color].indexes[a];
@@ -211,7 +211,7 @@ TransitionMatrix subset_mutation_matrix_meiosis_gamete(const TransitionMatrix &f
     const int widthP = type_info_gt_table[color].width;
     const int widthC = type_info_table[color].width;
 
-	TransitionMatrix ret{widthP,widthC};
+    TransitionMatrix ret{widthP,widthC};
 
     for(int x = 0; x < widthP; ++x) {
         const int gx = type_info_gt_table[color].indexes[x];
@@ -230,7 +230,7 @@ TransitionMatrix subset_mutation_matrix_mitosis_diploid(const TransitionMatrix &
 
     const int width = type_info_gt_table[color].width;
 
-	TransitionMatrix ret{width,width};
+    TransitionMatrix ret{width,width};
 
     for(int x = 0; x < width; ++x) {
         const int gx = type_info_gt_table[color].indexes[x];
@@ -248,7 +248,7 @@ TransitionMatrix subset_mutation_matrix_mitosis_haploid(const TransitionMatrix &
 
     const int width = type_info_table[color].width;
 
-	TransitionMatrix ret{width,width};
+    TransitionMatrix ret{width,width};
 
     for(int x = 0; x < width; ++x) {
         const int gx = type_info_table[color].indexes[x];
@@ -280,7 +280,7 @@ TransitionMatrixVector dng::create_mutation_matrices_subset(const TransitionMatr
         } else if(full_matrices[child].rows() == 4 && full_matrices[child].cols() == 4) {
             matrices[child] = subset_mutation_matrix_mitosis_haploid(full_matrices[child], color);
         } else if(full_matrices[child].rows() == 10 && full_matrices[child].cols() == 4) {
-        	matrices[child] = subset_mutation_matrix_meiosis_gamete(full_matrices[child], color);
+            matrices[child] = subset_mutation_matrix_meiosis_gamete(full_matrices[child], color);
         } else if(full_matrices[child].rows() == 0 && full_matrices[child].cols() == 0 ) {
             matrices[child] = {};
         } else {

--- a/src/lib/probability.cc
+++ b/src/lib/probability.cc
@@ -57,7 +57,7 @@ LogProbability::LogProbability(RelationshipGraph graph, params_t params) :
         GenotypeArray diploid_prior(1), haploid_prior(1);
         diploid_prior(0) = diploid_prior_[color](pileup::AlleleDepths::type_info_gt_table[color].indexes[0]);
         haploid_prior(0) = haploid_prior_[color](pileup::AlleleDepths::type_info_table[color].indexes[0]);
-        work_.SetFounders(diploid_prior, haploid_prior);
+        work_.SetGermline(diploid_prior, haploid_prior);
         work_.SetGenotypeLikelihoods(genotyper_, depths);
         double logdata = graph_.PeelForwards(work_, transition_matrices_[color]);
         prob_monomorphic_[color] = exp(logdata);
@@ -71,7 +71,7 @@ LogProbability::value_t LogProbability::operator()(const pileup::RawDepths &dept
     double scale = work_.SetGenotypeLikelihoods(genotyper_, depths, ref_index);
 
     // Set the prior probability of the founders given the reference
-    work_.SetFounders(diploid_prior_[ref_index], haploid_prior_[ref_index]);
+    work_.SetGermline(diploid_prior_[ref_index], haploid_prior_[ref_index]);
 
     // for(int i=0; i < full_transition_matrices_.size(); ++i) {
     //     std::cerr << i << "\t";
@@ -111,7 +111,7 @@ LogProbability::value_t LogProbability::operator()(const pileup::AlleleDepths &d
         // Set the prior probability of the founders given the reference
         GenotypeArray diploid_prior = DiploidPrior(ref_index, color);
         GenotypeArray haploid_prior = HaploidPrior(ref_index, color);
-        work_.SetFounders(diploid_prior, haploid_prior);
+        work_.SetGermline(diploid_prior, haploid_prior);
   
         // Calculate genotype likelihoods
         scale = work_.SetGenotypeLikelihoods(genotyper_, depths);

--- a/src/lib/relationship_graph.cc
+++ b/src/lib/relationship_graph.cc
@@ -171,7 +171,7 @@ bool dng::RelationshipGraph::Construct(const Pedigree& pedigree,
     CreatePeelingOps(pedigree_graph, node_ids, family_labels, pivots);
     ConstructPeelingMachine();
 
-    // PrintMachine(cerr);
+    PrintMachine(cerr);
     return true;
 }
 

--- a/src/lib/relationship_graph.cc
+++ b/src/lib/relationship_graph.cc
@@ -171,7 +171,7 @@ bool dng::RelationshipGraph::Construct(const Pedigree& pedigree,
     CreatePeelingOps(pedigree_graph, node_ids, family_labels, pivots);
     ConstructPeelingMachine();
 
-    PrintMachine(cerr);
+    //PrintMachine(cerr);
     return true;
 }
 


### PR DESCRIPTION
Replace `SetFounders` with `SetGermline` function.

Germline nodes with no lower data may not be pruned out when the relationship graph is simplified.
Therefore, we must initialize the germline nodes with ones to make sure peeling doesn't fail on complex pedigrees.

