### PR TITLE
Reject Aligned Reads flagged as supplemental

### DIFF
--- a/Tests/Unit/CMakeLists.txt
+++ b/Tests/Unit/CMakeLists.txt
@@ -38,6 +38,9 @@ endmacro()
 ###############################################################################
 # Add Unit tests based on CXX namespaces
 
+AddUnitTest(hts::hts)
+AddUnitTest(hts::bam)
+
 AddUnitTest(dng::io::ad)
 AddUnitTest(dng::io::bam)
 AddUnitTest(dng::genotype)
@@ -51,7 +54,6 @@ AddUnitTest(dng::relationship_graph)
 AddUnitTest(dng::seq)
 AddUnitTest(dng::stats)
 AddUnitTest(dng::utility)
-AddUnitTest(hts::hts)
 
 # These tests are broken by changes to the library
 # disable them for now so we can merge important changes

--- a/Tests/Unit/dng/regions.cc
+++ b/Tests/Unit/dng/regions.cc
@@ -22,6 +22,7 @@
 #include <dng/regions.h>
 
 #include "../testing.h"
+#include <dng/hts/hts.h>
 
 #include <fstream>
 
@@ -30,6 +31,7 @@
 
 using namespace dng::regions;
 using dng::detail::make_test_range;
+using hts::detail::make_data_url;
 
 BOOST_AUTO_TEST_CASE(test_region_parsing) {
     auto test_fail = [](std::string region_string) -> void {
@@ -91,12 +93,7 @@ BOOST_AUTO_TEST_CASE(test_region_parsing_with_bam) {
     using region_t = hts::bam::region_t;
 
     // Open Read our test data from Memory
-    std::string bamstr = "data:";
-    if(hts::version() >= 10400 ) {
-        // data: url format changed in htslib 1.4
-        bamstr += ",";
-    }
-    bamstr += bamtext;
+    std::string bamstr = make_data_url(bamtext);
 
     hts::bam::File bamfile(bamstr.c_str(), "r");
     // Sanity checks.  If these fail, then other tests will as well

--- a/Tests/Unit/hts/bam.cc
+++ b/Tests/Unit/hts/bam.cc
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2017 Reed A. Cartwright
+ * Authors:  Reed A. Cartwright <reed@cartwrig.ht>
+ *
+ * This file is part of DeNovoGear.
+ *
+ * DeNovoGear is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define BOOST_TEST_MODULE hts::bam
+
+#include <dng/hts/bam.h>
+
+#include "../testing.h"
+#include <dng/hts/hts.h>
+
+using namespace hts;
+using namespace hts::bam;
+using hts::detail::make_data_url;
+
+const char samwithflags[] = 
+    "@HD\tVN:1.5\tSO:coordinate\n"
+    "@SQ\tSN:ref\tLN:10\n"
+    "r001\t66\tref\t1\t40\t10M\t*\t0\t0\tAAAAAAAAAA\t*\n"
+    "r002\t4\tref\t1\t40\t10M\t*\t0\t0\tAAAAAAAAAA\t*\n"  // BAM_FUNMAP removed
+    "r003\t258\tref\t1\t40\t10M\t*\t0\t0\tAAAAAAAAAA\t*\n" // BAM_FSECONDARY removed
+    "r004\t514\tref\t1\t40\t10M\t*\t0\t0\tAAAAAAAAAA\t*\n" // BAM_FQCFAIL removed
+    "r005\t1026\tref\t1\t40\t10M\t*\t0\t0\tAAAAAAAAAA\t*\n" // BAM_FDUP removed
+    "r006\t2050\tref\t1\t40\t10M\t*\t0\t0\tAAAAAAAAAA\t*\n" // BAM_FSUPPLEMENTARY
+    "r007\t82\tref\t1\t40\t10M\t*\t0\t0\tAAAAAAAAAA\t*\n"    
+;
+
+BOOST_AUTO_TEST_CASE(test_file_read) {
+    std::string bamstr = make_data_url(samwithflags);
+    hts::bam::File bamfile(bamstr.c_str(), "r");
+    Alignment aln;
+    BOOST_REQUIRE_GE(bamfile.Read(&aln),0);
+    BOOST_CHECK_EQUAL(aln.qname(), "r001");
+    BOOST_REQUIRE_GE(bamfile.Read(&aln),0);
+    BOOST_CHECK_EQUAL(aln.qname(), "r007");
+    BOOST_CHECK_LE(bamfile.Read(&aln),0);
+}

--- a/Tests/Unit/testing.h
+++ b/Tests/Unit/testing.h
@@ -145,6 +145,8 @@ struct AutoTempFile {
     }
 };
 
+// function to create a 
+
 namespace {
 template<typename T>
 struct test_range {
@@ -221,9 +223,9 @@ operator<<(std::basic_ostream<CharType, CharTrait>& o, E m) {
     o << static_cast<typename std::underlying_type<E>::type>(m);
     return o;
 }
+}}} // namespace dng::detail::io
 
-}}}
-
+// allow pair of strings to be printed
 namespace std {
 template<typename CharType, typename CharTrait>
 inline

--- a/src/include/dng/hts/bam.h
+++ b/src/include/dng/hts/bam.h
@@ -194,7 +194,8 @@ public:
                     break;
                 }
             }
-            if(p->is_any(BAM_FUNMAP | BAM_FSECONDARY | BAM_FQCFAIL | BAM_FDUP)) {
+            if(p->is_any(BAM_FUNMAP | BAM_FQCFAIL | BAM_FDUP
+                | BAM_FSECONDARY | BAM_FSUPPLEMENTARY)) {
                 continue;
             }
             if(p->map_qual() < min_mapQ_) {

--- a/src/include/dng/hts/hts.h
+++ b/src/include/dng/hts/hts.h
@@ -98,6 +98,19 @@ inline unsigned long version() {
     return version_parse(hts_version());
 }
 
+namespace detail {
+template<typename S>
+std::string make_data_url(const S& str) {
+    // data: url format changed in htslib 1.4
+    std::string bamstr = "data:";
+    if(hts::version() >= 10400 ) {
+        bamstr += ",";
+    }
+    return bamstr+str;
+}
+
+} // namespace detail
+
 };
 
 #endif


### PR DESCRIPTION
Update `hts::bam::File` to skip reads marked as 'supplemental' for the same reasons we skip 'secondary reads'.