### PR TITLE
Fix memory leak related to BCFtools functions

### DIFF
--- a/src/dnm/bcf2Qcall.cc
+++ b/src/dnm/bcf2Qcall.cc
@@ -149,7 +149,7 @@ int bcf_2qcall(const bcf_hdr_t *hdr, bcf1_t *rec, Trio t, qcall_t *mom_snp,
       return err;
 
     // get I16 values from INFO field
-    std::array<int, 16> anno = std::array<int,16>();
+    std::array<int, 16> anno;
     if(read_I16(rec, hdr, anno) != 0) {
         d_rest = dp = 0;
     } else {

--- a/src/dnm/bcf2Qcall.cc
+++ b/src/dnm/bcf2Qcall.cc
@@ -58,9 +58,9 @@ void writeToSNPObject(snp_object_t *mom_snp, const bcf_hdr_t *hdr, bcf1_t *rec,
 
     // Get "DP" field for each sample if it exits. Otherwise use depth estimated
     // from I16 fields 9 and 11
-    int *res_array = NULL;
-    int n_res_array = 0;
-    int n_res = bcf_get_format_int32(hdr, rec, "DP", &res_array, &n_res_array);
+    int n_res_array = n_alleles*10;
+    auto res_array = hts::bcf::make_buffer<int>(n_res_array);
+    int n_res = hts::bcf::get_format_int32(hdr, rec, "DP", &res_array, &n_res_array);
     if(n_res >= 3) {
         mom_snp->depth = res_array[i];
     } else {
@@ -100,9 +100,9 @@ void writeToIndelObject(indel_t *mom_indel, const bcf_hdr_t *hdr, bcf1_t *rec,
     mom_indel->rms_mapQ = mq;
     strcpy(mom_indel->id, hdr->samples[i]);
 
-    int *res_array = NULL;
-    int n_res_array = 0;
-    int n_res = bcf_get_format_int32(hdr, rec, "DP", &res_array, &n_res_array);
+    int n_res_array = n_alleles*10;
+    auto res_array = hts::bcf::make_buffer<int>(n_res_array);
+    int n_res = hts::bcf::get_format_int32(hdr, rec, "DP", &res_array, &n_res_array);
     if(n_res >= 3) {
         mom_indel->depth = res_array[i];
     } else {
@@ -127,7 +127,7 @@ int bcf_2qcall(const bcf_hdr_t *hdr, bcf1_t *rec, Trio t, qcall_t *mom_snp,
                indel_t *child_indel, int &flag, int pl_type) {
 
     int a[4], k, g[10], l, map[4], k1, l1, j, i, i0, /*anno[16],*/ dp, mq, d_rest,
-        /*indel = 0,*/ found_trio = 3;
+	 /*indel = 0,*/ found_trio = 3;
 
     // Check if INDEL or SNP
     int indel = (bcf_get_variant_types(rec) == hts::bcf::File::INDEL);
@@ -149,9 +149,9 @@ int bcf_2qcall(const bcf_hdr_t *hdr, bcf1_t *rec, Trio t, qcall_t *mom_snp,
       return err;
 
     // get I16 values from INFO field
-    std::array<int, 16> anno;
+    std::array<int, 16> anno = std::array<int,16>();
     if(read_I16(rec, hdr, anno) != 0) {
-        d_rest = 0;
+        d_rest = dp = 0;
     } else {
         d_rest = dp = anno[0] + anno[1] + anno[2] + anno[3];
     }
@@ -182,7 +182,7 @@ int bcf_2qcall(const bcf_hdr_t *hdr, bcf1_t *rec, Trio t, qcall_t *mom_snp,
         }
 
         a[k + 1] = nt4_table[(int)alleles[s][0]];
-        if(a[k + 1] >= 0) {
+        if(a[k + 1] >= 0 && a[k + 1] < 4) {
             map[a[k + 1]] = k + 1;
         } else {
             k1 = k + 1;

--- a/src/dnm/parser.h
+++ b/src/dnm/parser.h
@@ -110,9 +110,9 @@ static int8_t nt4_table[256] = {
 
 static int get_pl_fields(const bcf_hdr_t *hdr, bcf1_t *rec, int pl_type, int n_samples, sample_vals_int &pl_fields) {
   if(pl_type == BCF_HT_INT) {
-    int *pl_array = NULL;
-    int n_pl_array = 0;
-    int n_pl = bcf_get_format_int32(hdr, rec, "PL", &pl_array, &n_pl_array);
+    int n_pl_array = n_samples*10;
+    auto pl_array = hts::bcf::make_buffer<int>(n_pl_array);
+    int n_pl = hts::bcf::get_format_int32(hdr, rec, "PL", &pl_array, &n_pl_array);
     if(n_pl <= 0) {
       return -6;
     } else {
@@ -125,9 +125,9 @@ static int get_pl_fields(const bcf_hdr_t *hdr, bcf1_t *rec, int pl_type, int n_s
       return 1;
     }
   } else if(pl_type == BCF_HT_REAL) {
-    float *pl_array = NULL;
-    int n_pl_array = 0;
-    int n_pl = bcf_get_format_float(hdr, rec, "PL", &pl_array, &n_pl_array);
+    int n_pl_array = n_samples*10;
+    auto pl_array = hts::bcf::make_buffer<float>(n_pl_array);
+    int n_pl = hts::bcf::get_format_float(hdr, rec, "PL", &pl_array, &n_pl_array);
     if(n_pl <= 0) {
       return -6;
     } else {
@@ -153,9 +153,9 @@ static int get_pl_fields(const bcf_hdr_t *hdr, bcf1_t *rec, int pl_type, int n_s
 static int read_I16(bcf1_t *rec, const bcf_hdr_t *hdr, std::array<int, 16> &anno) {
     std::vector<int> i16vals;
     //vcf.GetInfoValues("I16", i16vals);
-    int *dst = NULL;
-    int n_dst = 0;
-    int array_size = bcf_get_info_int32(hdr, rec, "I16", &dst, &n_dst);
+    int n_dst = 16;
+    auto dst = hts::bcf::make_buffer<int>(n_dst);
+    int array_size = hts::bcf::get_info_int32(hdr, rec, "I16", &dst, &n_dst);
 
     if(array_size == 0) {
         return -1;

--- a/src/include/dng/hts/bcf.h
+++ b/src/include/dng/hts/bcf.h
@@ -80,7 +80,35 @@ typedef bcf1_t BareVariant;
 inline
 int get_format_int32(const bcf_hdr_t *header, BareVariant *record, const char *tag, buffer_t<int>* buffer, int *capacity) {
     int *p = buffer->get();
-    int n = bcf_get_format_int32(header, record, "AD", &p, capacity);
+    int n = bcf_get_format_int32(header, record, tag, &p, capacity);
+    if(n == -4) {
+        throw std::bad_alloc{};
+    } else if(p != buffer->get()) {
+        // update pointer
+        buffer->release();
+        buffer->reset(p);
+    }
+    return n;
+}
+
+inline
+int get_format_float(const bcf_hdr_t *header, BareVariant *record, const char *tag, buffer_t<float>* buffer, int *capacity) {
+    float *p = buffer->get();
+    int n = bcf_get_format_float(header, record, tag, &p, capacity);
+    if(n == -4) {
+        throw std::bad_alloc{};
+    } else if(p != buffer->get()) {
+        // update pointer
+        buffer->release();
+        buffer->reset(p);
+    }
+    return n;
+}
+
+inline
+int get_info_int32(const bcf_hdr_t *header, BareVariant *record, const char *tag, buffer_t<int>* buffer, int *capacity) {
+    int *p = buffer->get();
+    int n = bcf_get_info_int32(header, record, tag, &p, capacity);
     if(n == -4) {
         throw std::bad_alloc{};
     } else if(p != buffer->get()) {


### PR DESCRIPTION
Added functions to wrap around BCFtools `bcf_get_*` type functions to prevent memory leakage.
Added check on `bcf2_qcall` function to ensure no segmentation fault when mapping ALT and REF values from BCF/VCF file.