### PR TITLE
Support reading stdin

### DIFF
--- a/Tests/DngCall/BamTest.cmake.in
+++ b/Tests/DngCall/BamTest.cmake.in
@@ -109,6 +109,14 @@ set(Region1-STDOUT-FAIL
 )
 
 ###############################################################################
+# Test if dng-call can identify mutations correctly from a pipe
+
+set(PipedTrio-CMD sh -c "cat trio.bam | @DNG_CALL_EXE@ -p ped/trio.ped -f trio.fasta.gz bam:-")
+set(PipedTrio-WD ${Trio-WD})
+set(PipedTrio-RESULT ${Trio-RESULT})
+set(PipedTrio-STDOUT ${Trio-STDOUT})
+
+###############################################################################
 # Add Tests
 
 include("@CMAKE_CURRENT_SOURCE_DIR@/CheckProcessTest.cmake")
@@ -122,4 +130,5 @@ CheckProcessTests(DngCall.Bam
   PartialPed
   EmptyPed
   Region1
+  PipedTrio
 )

--- a/Tests/DngCall/CramTest.cmake.in
+++ b/Tests/DngCall/CramTest.cmake.in
@@ -73,6 +73,14 @@ set(EmptyPed-WD "@TESTDATA_DIR@/human_trio/")
 set(EmptyPed-RESULT 0)
 
 ###############################################################################
+# Test if dng-call can identify mutations correctly from a pipe
+
+set(PipedTrio-CMD sh -c "cat trio.cram | @DNG_CALL_EXE@ -p ped/trio.ped -f trio.fasta.gz cram:-")
+set(PipedTrio-WD ${Trio-WD})
+set(PipedTrio-RESULT ${Trio-RESULT})
+set(PipedTrio-STDOUT ${Trio-STDOUT})
+
+###############################################################################
 # Add Tests
 
 include("@CMAKE_CURRENT_SOURCE_DIR@/CheckProcessTest.cmake")
@@ -84,4 +92,5 @@ CheckProcessTests(DngCall.Cram
   TagID
   PartialPed
   EmptyPed
+  PipedTrio
 )

--- a/Tests/DngCall/VcfTest.cmake.in
+++ b/Tests/DngCall/VcfTest.cmake.in
@@ -210,8 +210,8 @@ set(MissingData-STDOUT
 # Test if dng-call works on a pipe
 
 set(PipedTrio-CMD sh -c "cat bcftools/trio.mpileup.vcf | @DNG_CALL_EXE@ -p ped/trio.ped vcf:-")
-set(PipedTrio-WD "@TESTDATA_DIR@/human_trio")
-set(PipedTrio-RESULT 0)
+set(PipedTrio-WD ${Trio-WD})
+set(PipedTrio-RESULT ${Trio-RESULT})
 set(PipedTrio-STDOUT ${TrioMpileup-STDOUT})
 
 ###############################################################################

--- a/Tests/DngCall/VcfTest.cmake.in
+++ b/Tests/DngCall/VcfTest.cmake.in
@@ -207,6 +207,14 @@ set(MissingData-STDOUT
 )
 
 ###############################################################################
+# Test if dng-call works on a pipe
+
+set(PipedTrio-CMD sh -c "cat bcftools/trio.mpileup.vcf | @DNG_CALL_EXE@ -p ped/trio.ped vcf:-")
+set(PipedTrio-WD "@TESTDATA_DIR@/human_trio")
+set(PipedTrio-RESULT 0)
+set(PipedTrio-STDOUT ${TrioMpileup-STDOUT})
+
+###############################################################################
 # Add Tests
 
 include("@CMAKE_CURRENT_SOURCE_DIR@/CheckProcessTest.cmake")
@@ -223,4 +231,5 @@ CheckProcessTests(DngCall.Vcf
   TrioRegion
   TrioExtraSample
   MissingData
+  PipedTrio
 )

--- a/Tests/DngCall/VcfTest.cmake.in
+++ b/Tests/DngCall/VcfTest.cmake.in
@@ -210,8 +210,8 @@ set(MissingData-STDOUT
 # Test if dng-call works on a pipe
 
 set(PipedTrio-CMD sh -c "cat bcftools/trio.mpileup.vcf | @DNG_CALL_EXE@ -p ped/trio.ped vcf:-")
-set(PipedTrio-WD ${Trio-WD})
-set(PipedTrio-RESULT ${Trio-RESULT})
+set(PipedTrio-WD ${TrioMpileup-WD})
+set(PipedTrio-RESULT ${TrioMpileup-RESULT})
 set(PipedTrio-STDOUT ${TrioMpileup-STDOUT})
 
 ###############################################################################

--- a/Tests/DngLoglike/BamTest.cmake.in
+++ b/Tests/DngLoglike/BamTest.cmake.in
@@ -47,6 +47,13 @@ set(Region-STDERR
 )
 
 ###############################################################################
+# Test if dng-loglike works on a pipe
+set(PipedTrio-CMD sh -c "cat trio.bam | @DNG_LOGLIKE_EXE@ -p ped/trio.ped -f trio.fasta.gz bam:-")
+set(PipedTrio-WD ${BasicTest-WD})
+set(PipedTrio-RESULT ${BasicTest-RESULT})
+set(PipedTrio-STDOUT ${BasicTest-STDOUT})
+
+###############################################################################
 # Add Tests
 
 include("@CMAKE_CURRENT_SOURCE_DIR@/CheckProcessTest.cmake")
@@ -57,4 +64,5 @@ CheckProcessTests(DngLoglike.Bam
     MultiInput
     NoFasta
     Region
+    PipedTrio
 )

--- a/Tests/DngLoglike/CramTest.cmake.in
+++ b/Tests/DngLoglike/CramTest.cmake.in
@@ -46,6 +46,12 @@ set(Region-STDERR
     "Unknown contig name: 'A'"
 )
 
+###############################################################################
+# Test if dng-loglike works on a pipe
+set(PipedTrio-CMD sh -c "cat trio.cram | @DNG_LOGLIKE_EXE@ -p ped/trio.ped -f trio.fasta.gz cram:-")
+set(PipedTrio-WD ${BasicTest-WD})
+set(PipedTrio-RESULT ${BasicTest-RESULT})
+set(PipedTrio-STDOUT ${BasicTest-STDOUT})
 
 ###############################################################################
 # Add Tests
@@ -58,4 +64,5 @@ CheckProcessTests(DngLoglike.Cram
     MultiInput
     NoFasta
     Region
+    PipedTrio
 )

--- a/Tests/DngLoglike/VcfTest.cmake.in
+++ b/Tests/DngLoglike/VcfTest.cmake.in
@@ -1,7 +1,7 @@
 ###############################################################################
 # Test dng-loglike functioning with vcf file
 
-set(BasicTest-CMD @DNG_LOGLIKE_EXE@ -p ped/trio.ped -f trio.fasta.gz bcftools/trio.mpileup.vcf)
+set(BasicTest-CMD @DNG_LOGLIKE_EXE@ -p ped/trio.ped bcftools/trio.mpileup.vcf)
 set(BasicTest-WD "@TESTDATA_DIR@/human_trio")
 set(BasicTest-Result 0)
 set(BasicTest-STDOUT
@@ -29,6 +29,13 @@ set(MultiInput-STDERR
 )
 
 ###############################################################################
+# Test if dng-loglike works on a pipe
+set(PipedTrio-CMD sh -c "cat bcftools/trio.mpileup.vcf | @DNG_LOGLIKE_EXE@ -p ped/trio.ped vcf:-")
+set(PipedTrio-WD ${BasicTest-WD})
+set(PipedTrio-RESULT ${BasicTest-RESULT})
+set(PipedTrio-STDOUT ${BasicTest-STDOUT})
+
+###############################################################################
 # Add Tests
 
 include("@CMAKE_CURRENT_SOURCE_DIR@/CheckProcessTest.cmake")
@@ -37,4 +44,5 @@ CheckProcessTests(DngLoglike.Vcf
     BasicTest
     EmptyVcf
     MultiInput
+    PipedTrio
 )

--- a/src/include/dng/io/bam.h
+++ b/src/include/dng/io/bam.h
@@ -223,7 +223,9 @@ BamPileup BamPileup::open_and_setup(const A& arg) {
     BamPileup mpileup{arg.min_qlen, arg.rgtag};
     
     for(auto && str : arg.input) {
-        hts::bam::File input{str.c_str(), "r", arg.fasta.c_str(), arg.min_mapqual, arg.header.c_str()};
+        auto file = utility::extract_file_type(str);
+
+        hts::bam::File input{file.second.c_str(), "r", arg.fasta.c_str(), arg.min_mapqual, arg.header.c_str()};
         if(!input.is_open()) {
             throw std::runtime_error("Unable to open bam/sam/cram input file '" + str + "' for reading.");
         }

--- a/src/include/dng/io/bcf.h
+++ b/src/include/dng/io/bcf.h
@@ -134,7 +134,9 @@ int BcfPileup::AddFile(const char* filename) {
     int index = reader_.num_readers();
     assert(index == 0); // only support one input file at this time
 
-    if(reader_.AddReader(filename) == 0) {
+    auto file = utility::extract_file_type(filename);
+
+    if(reader_.AddReader(file.second.c_str()) == 0) {
         return 0;
     }
     ParseSampleLabels(index);

--- a/src/include/dng/utility.h
+++ b/src/include/dng/utility.h
@@ -265,7 +265,7 @@ typedef EnumFlags<FileCat> FileCatSet;
 
 // converts an extension to a file category
 FileCat file_category(const std::string &ext);
-// converts and input file to category and will throw if value is not supported
+// converts an input file to category and will throw if value is not supported
 FileCat input_category(const std::string &in, FileCatSet mask, FileCat def = FileCat::Unknown);
 
 // create a timestamp that contains the date and epoch

--- a/src/lib/utility.cc
+++ b/src/lib/utility.cc
@@ -92,7 +92,6 @@ FileCat file_category(const std::string &ext) {
 
 
 FileCat input_category(const std::string &in, FileCatSet mask, FileCat def) {
-
     std::string ext = extract_file_type(in).first;
     if(ext == "gz" || ext == "gzip" || ext == "bgz") {
     	std::string extr = boost::filesystem::change_extension(in, "").string();
@@ -105,7 +104,7 @@ FileCat input_category(const std::string &in, FileCatSet mask, FileCat def) {
     if(mask & cat) {
         return cat;
     } else {
-        throw std::runtime_error("Argument error: file type '" + ext + "' not supported. Input file was '" + in + "'.");
+        throw std::invalid_argument("file type '" + ext + "' not supported. Input file was '" + in + "'.");
     }
     return FileCat::Unknown;
 }


### PR DESCRIPTION
 Add support for reading from stdin by specifying the file type using prefix syntax, i.e. `vcf:-`.