### PR TITLE
Fix moving io::File with GCC 4.8 and 4.9

### DIFF
--- a/src/include/dng/io/file.h
+++ b/src/include/dng/io/file.h
@@ -63,7 +63,7 @@ public:
         } else {
             return Attach(std::cout.rdbuf());
         }
-        return false;
+        return Attach(nullptr);
     }
     bool Attach(std::streambuf *buffer) {
         stream_.rdbuf(buffer);

--- a/src/include/dng/io/file.h
+++ b/src/include/dng/io/file.h
@@ -46,14 +46,16 @@ public:
     bool Open(const std::string &filename, std::ios_base::openmode mode = std::ios_base::in) {
         std::tie(type_label_, path_) = utility::extract_file_type(filename);
         buffer_ = nullptr;
+        file_.reset();
         if(path_.empty()) {
             // don't do anything, just setup type
         } else if(path_ != "-") {
             // if path is not "-" open a file
-            file_.open(path_.c_str(), mode);
+            file_.reset(new std::fstream);
+            file_.get()->open(path_.c_str(), mode);
             // if file is open, associate it with the stream
-            if(file_.is_open()) {
-                buffer_ = file_.rdbuf();
+            if(file_.get()->is_open()) {
+                buffer_ = file_.get()->rdbuf();
             }
         } else if((mode & std::ios_base::in) == (mode & std::ios_base::out)) {
             // can't do anything if both are set or none are set
@@ -87,7 +89,8 @@ protected:
 
 private:
     bool is_open_{false};
-    std::fstream file_;
+    
+    std::unique_ptr<std::fstream> file_;
 };
 
 inline

--- a/src/include/dng/io/file.h
+++ b/src/include/dng/io/file.h
@@ -45,60 +45,51 @@ public:
 
     bool Open(const std::string &filename, std::ios_base::openmode mode = std::ios_base::in) {
         std::tie(type_label_, path_) = utility::extract_file_type(filename);
-        buffer_ = nullptr;
-        file_.reset();
         if(path_.empty()) {
             // don't do anything, just setup type
         } else if(path_ != "-") {
             // if path is not "-" open a file
-            file_.reset(new std::fstream);
-            file_.get()->open(path_.c_str(), mode);
+            buffer_.reset(new std::filebuf);
+            std::filebuf *p = static_cast<std::filebuf*>(buffer_.get());
+            p->open(path_.c_str(), mode);
             // if file is open, associate it with the stream
-            if(file_.get()->is_open()) {
-                buffer_ = file_.get()->rdbuf();
+            if(p->is_open()) {
+                return Attach(buffer_.get());
             }
         } else if((mode & std::ios_base::in) == (mode & std::ios_base::out)) {
             // can't do anything if both are set or none are set
         } else if(mode & std::ios_base::in) {
-            buffer_ = std::cin.rdbuf();
+            return Attach(std::cin.rdbuf());
         } else {
-            buffer_ = std::cout.rdbuf();
+            return Attach(std::cout.rdbuf());
         }
-        return Attach();
+        return false;
     }
     bool Attach(std::streambuf *buffer) {
-        is_open_ = (buffer != nullptr);
         stream_.rdbuf(buffer);
         stream_.unsetf(std::ios_base::skipws);
-        return is_open_;
-    }
-    bool Attach() {
-        return Attach(buffer_);
+        return is_open();
     }
 
-    bool is_open() const { return is_open_; }
+    bool is_open() const { return stream_.rdbuf() != nullptr; }
     operator bool() const { return is_open(); }
 
     std::string path() const { return path_.native(); }
 
 protected:
     std::iostream stream_{nullptr};
-    std::streambuf *buffer_{nullptr};
     boost::filesystem::path path_;
     std::string type_label_;
 
 private:
-    bool is_open_{false};
-    
-    std::unique_ptr<std::fstream> file_;
+    std::unique_ptr<std::streambuf> buffer_;    
 };
 
 inline
 File::File(File&& other) : 
     buffer_{std::move(other.buffer_)},
     path_{std::move(other.path_)},
-    type_label_{std::move(other.type_label_)},
-    file_{std::move(other.file_)}
+    type_label_{std::move(other.type_label_)}
 {
     std::streambuf *buffer = other.stream_.rdbuf();
     Attach(buffer);
@@ -114,8 +105,6 @@ File& File::operator=(File&& other) {
     buffer_ = std::move(other.buffer_);
     path_ = std::move(other.path_);
     type_label_ = std::move(other.type_label_);
-
-    file_ = std::move(other.file_);
 
     std::streambuf *buffer = other.stream_.rdbuf();
     Attach(buffer);

--- a/src/include/dng/io/ped.h
+++ b/src/include/dng/io/ped.h
@@ -43,7 +43,7 @@ Pedigree Ped::Parse() {
     if(!is_open()) {
         return {};
     }
-    return Pedigree::parse_text(io::istreambuf_range(buffer_));
+    return Pedigree::parse_text(io::istreambuf_range(stream_.rdbuf()));
 }
 
 inline


### PR DESCRIPTION
To allow io::File to be moved with incomplete std libraries, change io::File to hold a `unique_ptr` to a stream buffer instead of a stream object.