### PR TITLE
Support Producing vcf.gz files

### DIFF
--- a/Tests/DngCall/VcfTest.cmake.in
+++ b/Tests/DngCall/VcfTest.cmake.in
@@ -196,6 +196,24 @@ set(PipedTrio-RESULT ${TrioMpileup-RESULT})
 set(PipedTrio-STDOUT ${TrioMpileup-STDOUT})
 
 ###############################################################################
+# Test if dng-call can output specific file types
+
+set(OutputVcf-CMD sh -c "@DNG_CALL_EXE@ -p ped/trio.ped -o vcf:- bcftools/trio.call.vcf | htsfile -")
+set(OutputVcf-WD ${TrioMpileup-WD})
+set(OutputVcf-RESULT 0)
+set(OutputVcf-STDOUT "^-:\tVCF version [0-9.]+ variant calling text\r?\n$")
+
+set(OutputVcfGz-CMD sh -c "@DNG_CALL_EXE@ -p ped/trio.ped -o vcf.gz:- bcftools/trio.call.vcf | htsfile -")
+set(OutputVcfGz-WD ${TrioMpileup-WD})
+set(OutputVcfGz-RESULT 0)
+set(OutputVcfGz-STDOUT "^-:\tVCF version [0-9.]+ BGZF-compressed variant calling data\r?\n$")
+
+set(OutputBcf-CMD sh -c "@DNG_CALL_EXE@ -p ped/trio.ped -o bcf:- bcftools/trio.call.vcf | htsfile -")
+set(OutputBcf-WD ${TrioMpileup-WD})
+set(OutputBcf-RESULT 0)
+set(OutputBcf-STDOUT "^-:\tBCF version [0-9.]+ compressed variant calling data\r?\n$")
+
+###############################################################################
 # Add Tests
 
 include("@CMAKE_CURRENT_SOURCE_DIR@/CheckProcessTest.cmake")
@@ -213,4 +231,7 @@ CheckProcessTests(DngCall.Vcf
   TrioExtraSample
   MissingData
   PipedTrio
+  OutputVcf
+  OutputVcfGz
+  OutputBcf
 )

--- a/Tests/Unit/dng/utility.cc
+++ b/Tests/Unit/dng/utility.cc
@@ -173,28 +173,42 @@ BOOST_AUTO_TEST_CASE(test_to_pretty) {
 }
 
 BOOST_AUTO_TEST_CASE(test_extract_file_type) {
-    using pair = std::pair<std::string,std::string>;
+    auto test = [](std::string filename, file_type_t expected) {
+        BOOST_TEST_CONTEXT("filename=" << filename) {
+        auto test = extract_file_type(filename);
+        BOOST_CHECK_EQUAL(test.path, expected.path);
+        BOOST_CHECK_EQUAL(test.type_ext, expected.type_ext);
+        BOOST_CHECK_EQUAL(test.compress_ext, expected.compress_ext);
+    }};
 
-    BOOST_CHECK_EQUAL(extract_file_type("foo.bar"), pair("bar", "foo.bar"));
-    BOOST_CHECK_EQUAL(extract_file_type("my:foo.bar"), pair("my", "foo.bar"));
-    BOOST_CHECK_EQUAL(extract_file_type(".bar"), pair("", ".bar"));
-    BOOST_CHECK_EQUAL(extract_file_type("my:.foo.bar"), pair("my",".foo.bar"));
-    BOOST_CHECK_EQUAL(extract_file_type(".foo.bar"), pair("bar",".foo.bar"));
-    BOOST_CHECK_EQUAL(extract_file_type(""), pair("", ""));
-    BOOST_CHECK_EQUAL(extract_file_type(std::string{}), pair({},{}));
-    //BOOST_CHECK(extract_file_type("C:\\foo.bar"), pair("bar"},string{"C:\\foo.bar"}));
-    //BOOST_CHECK(extract_file_type("CC:C:\\foo.bar"), pair("CC"},string{"C:\\foo.bar"}));
+    test("foo.bar", {"foo.bar", "bar"});
+    test("my:foo.bar", {"foo.bar", "my"});
+    test(".bar", {".bar", ""});
+    test("my:.foo.bar", {".foo.bar", "my"});
+    test(".foo.bar", {".foo.bar", "bar"});
+    test("", {"", ""});
+    test(std::string{}, {{},{}});
 
-    BOOST_CHECK_EQUAL(extract_file_type("bcf:test"), pair("bcf", "test"));
-    BOOST_CHECK_EQUAL(extract_file_type("vcf:-"), pair("vcf", "-"));
-    BOOST_CHECK_EQUAL(extract_file_type("vcf:"), pair("vcf", ""));
-    BOOST_CHECK_EQUAL(extract_file_type("test.bcf"), pair("bcf", "test.bcf"));
-    BOOST_CHECK_EQUAL(extract_file_type("test.vcf"), pair("vcf", "test.vcf"));
+    test("bcf:test", {"test", "bcf"});
+    test("vcf:-", {"-", "vcf"});
+    test("vcf:", {"", "vcf"});
+    test("test.bcf", {"test.bcf","bcf"});
+    test("test.vcf", {"test.vcf", "vcf"});
 
-    BOOST_CHECK_EQUAL(extract_file_type(" \f\n\r\t\vfoo.bar \f\n\r\t\v"), pair("bar", "foo.bar"));
-    BOOST_CHECK_EQUAL(extract_file_type(" \f\n\r\t\vmy:foo.bar \f\n\r\t\v"), pair("my", "foo.bar"));
-    BOOST_CHECK_EQUAL(extract_file_type(" \f\n\r\t\v.bar \f\n\r\t\v"), pair("", ".bar"));
-    BOOST_CHECK_EQUAL(extract_file_type(" \f\n\r\t\v"), pair({},{}));
+    test(" \f\n\r\t\vfoo.bar \f\n\r\t\v", {"foo.bar", "bar"});
+    test(" \f\n\r\t\vmy:foo.bar \f\n\r\t\v", {"foo.bar", "my"});
+    test(" \f\n\r\t\v.bar \f\n\r\t\v", {".bar", ""});
+    test(" \f\n\r\t\v", {{},{}});
+
+    test("test.vcf.gz", {"test.vcf.gz", "vcf", "gz"});
+    test("test.vcf.gzip", {"test.vcf.gzip", "vcf", "gzip"});
+    test("test.vcf.bgz", {"test.vcf.bgz", "vcf", "bgz"});
+    test(".test.vcf.gz", {".test.vcf.gz", "vcf", "gz"});
+    test("test.gz", {"test.gz", "", "gz"});
+    test("vcf.gz:test", {"test", "vcf", "gz"});
+    test("vcf.gz:test.txt", {"test.txt", "vcf", "gz"});
+    test("gz:test.txt", {"test.txt", "", "gz"});
+    test(".test.gz", {".test.gz", "", "gz"});
 }
 
 BOOST_AUTO_TEST_CASE(test_file_category) {

--- a/src/include/dng/io/bam.h
+++ b/src/include/dng/io/bam.h
@@ -225,7 +225,7 @@ BamPileup BamPileup::open_and_setup(const A& arg) {
     for(auto && str : arg.input) {
         auto file = utility::extract_file_type(str);
 
-        hts::bam::File input{file.second.c_str(), "r", arg.fasta.c_str(), arg.min_mapqual, arg.header.c_str()};
+        hts::bam::File input{file.path.c_str(), "r", arg.fasta.c_str(), arg.min_mapqual, arg.header.c_str()};
         if(!input.is_open()) {
             throw std::runtime_error("Unable to open bam/sam/cram input file '" + str + "' for reading.");
         }

--- a/src/include/dng/io/bcf.h
+++ b/src/include/dng/io/bcf.h
@@ -89,7 +89,7 @@ template<typename A>
 inline
 BcfPileup BcfPileup::open_and_setup(const A& arg) {
     if(arg.input.size() > 1) {
-        throw std::runtime_error("processing more than one variant file at a time is not supported.");
+        throw std::invalid_argument("processing more than one variant file at a time is not supported.");
     }
 
     BcfPileup mpileup;
@@ -136,7 +136,7 @@ int BcfPileup::AddFile(const char* filename) {
 
     auto file = utility::extract_file_type(filename);
 
-    if(reader_.AddReader(file.second.c_str()) == 0) {
+    if(reader_.AddReader(file.path.c_str()) == 0) {
         return 0;
     }
     ParseSampleLabels(index);

--- a/src/include/dng/io/file.h
+++ b/src/include/dng/io/file.h
@@ -44,7 +44,11 @@ public:
     }
 
     bool Open(const std::string &filename, std::ios_base::openmode mode = std::ios_base::in) {
-        std::tie(type_label_, path_) = utility::extract_file_type(filename);
+        auto file_type = utility::extract_file_type(filename);
+        path_ = file_type.path;
+        type_label_ = file_type.type_ext;
+        compression_ = file_type.compress_ext;
+
         if(path_.empty()) {
             // don't do anything, just setup type
         } else if(path_ != "-") {
@@ -80,6 +84,7 @@ protected:
     std::iostream stream_{nullptr};
     boost::filesystem::path path_;
     std::string type_label_;
+    std::string compression_;
 
 private:
     std::unique_ptr<std::streambuf> buffer_;    

--- a/src/include/dng/io/utility.h
+++ b/src/include/dng/io/utility.h
@@ -96,9 +96,9 @@ inline std::string at_slurp(std::string &ss, std::ios_base::openmode mode = std:
         return {'.'};
     }
     auto filename = utility::extract_file_type(ss.c_str()+1);
-    std::ifstream in{filename.second, mode};
+    std::ifstream in{filename.path, mode};
     ss = slurp(in);
-    return filename.first;
+    return filename.type_ext;
 }
 
 }

--- a/src/include/dng/utility.h
+++ b/src/include/dng/utility.h
@@ -288,14 +288,15 @@ inline T lphred1m(double p, T m = std::numeric_limits<T>::max()) {
 }
 
 // extracts extension and filename from both file.foo and ext:file.foo
+struct file_type_t {
+    std::string path;
+    std::string type_ext;
+    std::string compress_ext;
+};
+
 // returns {ext, file.foo}
 // trims whitespace as well
-std::pair<std::string, std::string> extract_file_type(const char *path);
-
-inline
-std::pair<std::string, std::string> extract_file_type(const std::string &path) {
-    return extract_file_type(path.c_str());
-}
+file_type_t extract_file_type(std::string path);
 
 // a strongly-typed enum for file category
 enum class FileCat {
@@ -307,7 +308,6 @@ enum class FileCat {
 ENABLE_ENUMFLAGS(FileCat);
 
 using FileCatSet = EnumFlags<FileCat>;
-
 
 // converts an extension to a file category
 FileCat file_category(const std::string &ext);

--- a/src/lib/task/call.cc
+++ b/src/lib/task/call.cc
@@ -119,18 +119,21 @@ std::pair<std::string, std::string> vcf_get_output_mode(
     const task::Call::argument_type &arg) {
     using boost::algorithm::iequals;
 
-    if(arg.output.empty() || arg.output == "-")
+    if(arg.output.empty() || arg.output == "-") {
         return {"-", "w"};
-    auto ret = utility::extract_file_type(arg.output);
-    if(iequals(ret.first, "bcf")) {
-        return {ret.second, "wb"};
-    } else if(iequals(ret.first, "vcf")) {
-        return {ret.second, "w"};
-    } else {
-        throw std::runtime_error("Unknown file format '" + ret.second + "' for output '"
-                                 + arg.output + "'.");
     }
-    return {};
+    auto ret = utility::extract_file_type(arg.output);
+    if(iequals(ret.type_ext, "bcf")) {
+        return {ret.path, "wb"};
+    }
+    if(iequals(ret.type_ext, "vcf")) {
+        if(ret.compress_ext.empty()){
+            return {ret.path, "w"};
+        }
+        return {ret.path, "wz"};
+    }
+    throw std::runtime_error("Unknown file format '" +
+        ret.type_ext + "' for output '" + arg.output + "'.");
 }
 
 // Helper function for writing the vcf header information

--- a/src/lib/utility.cc
+++ b/src/lib/utility.cc
@@ -49,19 +49,26 @@ file_type_t extract_file_type(std::string path) {
         auto ext = path.substr(0, colon);
         path.erase(0,colon+1);
         // Format ext.gz:path ???
-        auto gz = is_compressed(ext);
+        auto gz = is_compressed('.'+ext);
         if(!gz.empty()) {
-            ext.erase(ext.size()-(gz.size()+1));
+            // Format gz:path
+            if(gz.size() == ext.size()) {
+                ext.erase();
+            } else {
+                auto gz_pos = ext.size() - (gz.size()+1);
+                ext.erase(gz_pos);
+            }
         }
         return {path, ext, gz};
     }
     // Format path.gz ???
     auto gz = is_compressed(path);
-    auto ext_pos = path.find_last_of('.', path.size()-(gz.size()+1));
-    if(ext_pos == npos) {
+    auto gz_pos = path.size() - (gz.empty() ? 0 : gz.size()+1);
+    auto ext_pos = path.find_last_of('.', gz_pos-1);
+    if(ext_pos == npos || ext_pos == 0) {
         return {path, {}, gz};
     }
-    auto ext = path.substr(ext_pos+1, path.size()-(gz.size()+1)-(ext_pos+1));
+    auto ext = path.substr(ext_pos+1, gz_pos-(ext_pos+1));
     return {path, ext, gz};
 }
 


### PR DESCRIPTION
Allow dng-call to create compressed vcf output if a vcf.gz extension is used in the output file.

`extract_file_type` has been rewritten to recognize compressed extensions.