### PR TITLE
Make integration tests path more robust

### DIFF
--- a/Tests/DngCall/BamTest.cmake.in
+++ b/Tests/DngCall/BamTest.cmake.in
@@ -1,7 +1,7 @@
 ###############################################################################
 # Test if dng-call can identify mutations correctly from a bam file
 
-set(Trio-CMD @DNG_CALL_EXE@ -p ped/trio.ped -f trio.fasta.gz trio.bam)
+set(Trio-CMD "@DNG_CALL_EXE@" -p ped/trio.ped -f trio.fasta.gz trio.bam)
 set(Trio-WD "@TESTDATA_DIR@/human_trio")
 set(Trio-RESULT 0)
 set(Trio-STDOUT
@@ -37,21 +37,21 @@ set(Trio-STDOUT
 ###############################################################################
 # Test if dng-call --rgtag works properly
 
-set(TagLB-CMD @DNG_CALL_EXE@ --rgtag "LB" -p ped/trio.ped -f trio.fasta.gz trio.bam)
+set(TagLB-CMD "@DNG_CALL_EXE@" --rgtag "LB" -p ped/trio.ped -f trio.fasta.gz trio.bam)
 set(TagLB-WD "@TESTDATA_DIR@/human_trio")
 set(TagLB-RESULT 0)
 set(TagLB-STDOUT
   "FORMAT\tGL/NA12892\tGL/NA12891\tLB/NA12891/Solexa-135851\tLB/NA12878/Solexa-135852\tLB/NA12892/Solexa-135853\r?\n"
 )
 
-set(TagSM-CMD @DNG_CALL_EXE@ --rgtag "SM" -p ped/trio.ped -f trio.fasta.gz trio.bam)
+set(TagSM-CMD "@DNG_CALL_EXE@" --rgtag "SM" -p ped/trio.ped -f trio.fasta.gz trio.bam)
 set(TagSM-WD "@TESTDATA_DIR@/human_trio")
 set(TagSM-RESULT 0)
 set(TagSM-STDOUT
   "FORMAT\tGL/NA12892\tGL/NA12891\tLB/NA12891\tLB/NA12878\tLB/NA12892\r?\n"
 )
 
-set(TagID-CMD @DNG_CALL_EXE@ --rgtag "ID" -p ped/trio.ped -f trio.fasta.gz trio.bam)
+set(TagID-CMD "@DNG_CALL_EXE@" --rgtag "ID" -p ped/trio.ped -f trio.fasta.gz trio.bam)
 set(TagID-WD "@TESTDATA_DIR@/human_trio")
 set(TagID-RESULT 0)
 set(TagID-STDOUT
@@ -61,7 +61,7 @@ set(TagID-STDOUT
 ###############################################################################
 # Test if dng-call --header works properly
 
-set(SepHeader1-CMD @DNG_CALL_EXE@ --header trio_new_header.sam -p ped/trio.ped -f trio.fasta.gz trio.bam)
+set(SepHeader1-CMD "@DNG_CALL_EXE@" --header trio_new_header.sam -p ped/trio.ped -f trio.fasta.gz trio.bam)
 set(SepHeader1-WD "@TESTDATA_DIR@/human_trio")
 set(SepHeader1-RESULT 0)
 set(SepHeader1-STDOUT
@@ -71,7 +71,7 @@ set(SepHeader1-STDOUT
 ###############################################################################
 # Test if dng-call crashes on partial pedigree
 
-set(PartialPed-CMD @DNG_CALL_EXE@ --ped ped/duo.ped --fasta trio.fasta.gz trio.bam)
+set(PartialPed-CMD "@DNG_CALL_EXE@" --ped ped/duo.ped --fasta trio.fasta.gz trio.bam)
 set(PartialPed-WD "@TESTDATA_DIR@/human_trio/")
 set(PartialPed-RESULT 0)
 set(PartialPed-STDOUT
@@ -81,7 +81,7 @@ set(PartialPed-STDOUT
 ###############################################################################
 # Test if dng-call crashes on empty pedigree
 
-set(EmptyPed-CMD @DNG_CALL_EXE@ --ped ped/empty.ped --fasta trio.fasta.gz trio.bam)
+set(EmptyPed-CMD "@DNG_CALL_EXE@" --ped ped/empty.ped --fasta trio.fasta.gz trio.bam)
 set(EmptyPed-WD "@TESTDATA_DIR@/human_trio/")
 set(EmptyPed-RESULT 0)
 
@@ -90,7 +90,7 @@ set(EmptyPed-RESULT 0)
 
 # "5:126,385,700-126,385,704 5:126,385,706-126,385,710"
 
-set(Region1-CMD @DNG_CALL_EXE@ -m 0 --region "5:126,385,700-126,385,704 5:126,385,706-126,385,710" --ped ped/trio.ped --fasta trio.fasta.gz trio.bam)
+set(Region1-CMD "@DNG_CALL_EXE@" -m 0 --region "5:126,385,700-126,385,704 5:126,385,706-126,385,710" --ped ped/trio.ped --fasta trio.fasta.gz trio.bam)
 set(Region1-WD "@TESTDATA_DIR@/human_trio/")
 set(Region1-RESULT 0)
 set(Region1-STDOUT
@@ -114,7 +114,7 @@ set(Region1-STDOUT-FAIL
 ###############################################################################
 # Test if dng-call can identify mutations correctly from a pipe
 
-set(PipedTrio-CMD sh -c "cat trio.bam | @DNG_CALL_EXE@ -p ped/trio.ped -f trio.fasta.gz bam:-")
+set(PipedTrio-CMD sh -c "cat trio.bam | '@DNG_CALL_EXE@' -p ped/trio.ped -f trio.fasta.gz bam:-")
 set(PipedTrio-WD ${Trio-WD})
 set(PipedTrio-RESULT ${Trio-RESULT})
 set(PipedTrio-STDOUT ${Trio-STDOUT})

--- a/Tests/DngCall/CramTest.cmake.in
+++ b/Tests/DngCall/CramTest.cmake.in
@@ -1,7 +1,7 @@
 ###############################################################################
 # Test if dng-call can identify mutations correctly from a cram file
 
-set(Trio-CMD @DNG_CALL_EXE@ -p ped/trio.ped -f trio.fasta.gz trio.cram)
+set(Trio-CMD "@DNG_CALL_EXE@" -p ped/trio.ped -f trio.fasta.gz trio.cram)
 set(Trio-WD "@TESTDATA_DIR@/human_trio")
 set(Trio-RESULT 0)
 set(Trio-STDOUT
@@ -37,21 +37,21 @@ set(Trio-STDOUT
 ###############################################################################
 # Test if dng-call --rgtag works properly
 
-set(TagLB-CMD @DNG_CALL_EXE@ --rgtag "LB" -p ped/trio.ped -f trio.fasta.gz trio.cram)
+set(TagLB-CMD "@DNG_CALL_EXE@" --rgtag "LB" -p ped/trio.ped -f trio.fasta.gz trio.cram)
 set(TagLB-WD "@TESTDATA_DIR@/human_trio")
 set(TagLB-RESULT 0)
 set(TagLB-STDOUT
   "FORMAT\tGL/NA12892\tGL/NA12891\tLB/NA12891/Solexa-135851\tLB/NA12878/Solexa-135852\tLB/NA12892/Solexa-135853\r?\n"
 )
 
-set(TagSM-CMD @DNG_CALL_EXE@ --rgtag "SM" -p ped/trio.ped -f trio.fasta.gz trio.cram)
+set(TagSM-CMD "@DNG_CALL_EXE@" --rgtag "SM" -p ped/trio.ped -f trio.fasta.gz trio.cram)
 set(TagSM-WD "@TESTDATA_DIR@/human_trio")
 set(TagSM-RESULT 0)
 set(TagSM-STDOUT
   "FORMAT\tGL/NA12892\tGL/NA12891\tLB/NA12891\tLB/NA12878\tLB/NA12892\r?\n"
 )
 
-set(TagID-CMD @DNG_CALL_EXE@ --rgtag "ID" -p ped/trio.ped -f trio.fasta.gz trio.cram)
+set(TagID-CMD "@DNG_CALL_EXE@" --rgtag "ID" -p ped/trio.ped -f trio.fasta.gz trio.cram)
 set(TagID-WD "@TESTDATA_DIR@/human_trio")
 set(TagID-RESULT 0)
 set(TagID-STDOUT
@@ -61,7 +61,7 @@ set(TagID-STDOUT
 ###############################################################################
 # Test if dng-call crashes on partial pedigree
 
-set(PartialPed-CMD @DNG_CALL_EXE@ --fasta trio.fasta.gz --ped ped/duo.ped trio.cram)
+set(PartialPed-CMD "@DNG_CALL_EXE@" --fasta trio.fasta.gz --ped ped/duo.ped trio.cram)
 set(PartialPed-WD "@TESTDATA_DIR@/human_trio/")
 set(PartialPed-RESULT 0)
 set(PartialPed-STDOUT
@@ -71,14 +71,14 @@ set(PartialPed-STDOUT
 ###############################################################################
 # Test if dng-call crashes on empty pedigree
 
-set(EmptyPed-CMD @DNG_CALL_EXE@ --fasta trio.fasta.gz --ped ped/empty.ped trio.cram)
+set(EmptyPed-CMD "@DNG_CALL_EXE@" --fasta trio.fasta.gz --ped ped/empty.ped trio.cram)
 set(EmptyPed-WD "@TESTDATA_DIR@/human_trio/")
 set(EmptyPed-RESULT 0)
 
 ###############################################################################
 # Test if dng-call can identify mutations correctly from a pipe
 
-set(PipedTrio-CMD sh -c "cat trio.cram | @DNG_CALL_EXE@ -p ped/trio.ped -f trio.fasta.gz cram:-")
+set(PipedTrio-CMD sh -c "cat trio.cram | '@DNG_CALL_EXE@' -p ped/trio.ped -f trio.fasta.gz cram:-")
 set(PipedTrio-WD ${Trio-WD})
 set(PipedTrio-RESULT ${Trio-RESULT})
 set(PipedTrio-STDOUT ${Trio-STDOUT})

--- a/Tests/DngCall/RunTest.cmake.in
+++ b/Tests/DngCall/RunTest.cmake.in
@@ -1,4 +1,4 @@
-set(Help-CMD @DNG_CALL_EXE@ --help)
+set(Help-CMD "@DNG_CALL_EXE@" --help)
 set(Help-WD ".")
 set(Help-RESULT 0)
 set(Help-STDERR "Usage:\n  dng call")

--- a/Tests/DngCall/VcfTest.cmake.in
+++ b/Tests/DngCall/VcfTest.cmake.in
@@ -1,14 +1,14 @@
 ###############################################################################
 # Test if dng-call crashes on partial pedigrees
 
-set(PartialPed-CMD @DNG_CALL_EXE@ --ped ped/duo.ped bcftools/trio.call.vcf)
+set(PartialPed-CMD "@DNG_CALL_EXE@" --ped ped/duo.ped bcftools/trio.call.vcf)
 set(PartialPed-WD "@TESTDATA_DIR@/human_trio/")
 set(PartialPed-RESULT 0)
 set(PartialPed-STDOUT
   "##PEDIGREE=<Derived=LB/NA12878,Original=GL/1,OriginalMR=0\\.0,Ploidy=2,Germline=1,Somatic=1,Library=1>"
 )
 
-set(PartialPed2-CMD @DNG_CALL_EXE@ -m 0 --ped ped/trio.ped vcf/duo.vcf)
+set(PartialPed2-CMD "@DNG_CALL_EXE@" -m 0 --ped ped/trio.ped vcf/duo.vcf)
 set(PartialPed2-WD "@TESTDATA_DIR@/human_trio/")
 set(PartialPed2-RESULT 0)
 set(PartialPed2-STDOUT
@@ -22,14 +22,14 @@ set(PartialPed2-STDOUT-FAIL
 ###############################################################################
 # Test if dng-call crashes on empty pedigrees
 
-set(EmptyPed-CMD @DNG_CALL_EXE@ --ped ped/empty.ped bcftools/trio.call.vcf)
+set(EmptyPed-CMD "@DNG_CALL_EXE@" --ped ped/empty.ped bcftools/trio.call.vcf)
 set(EmptyPed-WD "@TESTDATA_DIR@/human_trio/")
 set(EmptyPed-RESULT 0)
 
 ###############################################################################
 # Test if dng-call works on a trio with mpileup format
 
-set(TrioMpileup-CMD @DNG_CALL_EXE@ -p ped/trio.ped bcftools/trio.mpileup.vcf)
+set(TrioMpileup-CMD "@DNG_CALL_EXE@" -p ped/trio.ped bcftools/trio.mpileup.vcf)
 set(TrioMpileup-WD "@TESTDATA_DIR@/human_trio")
 set(TrioMpileup-RESULT 0)
 set(TrioMpileup-STDOUT
@@ -60,12 +60,12 @@ set(TrioMpileup-STDOUT
 ###############################################################################
 # Test if dng-call works on a trio with bcftools call
 
-set(TrioBcftoolsAutosomal-CMD @DNG_CALL_EXE@ -M autosomal -p ped/trio.ped bcftools/trio.call.vcf)
+set(TrioBcftoolsAutosomal-CMD "@DNG_CALL_EXE@" -M autosomal -p ped/trio.ped bcftools/trio.call.vcf)
 set(TrioBcftoolsAutosomal-WD "@TESTDATA_DIR@/human_trio")
 set(TrioBcftoolsAutosomal-RESULT 0)
 set(TrioBcftoolsAutosomal-STDOUT "${TrioMpileup-STDOUT}")
 
-set(TrioBcftoolsXLinked-CMD @DNG_CALL_EXE@ -M xlinked -p ped/trio.ped bcftools/trio.call.vcf)
+set(TrioBcftoolsXLinked-CMD "@DNG_CALL_EXE@" -M xlinked -p ped/trio.ped bcftools/trio.call.vcf)
 set(TrioBcftoolsXLinked-WD "@TESTDATA_DIR@/human_trio")
 set(TrioBcftoolsXLinked-RESULT 0)
 set(TrioBcftoolsXLinked-STDOUT
@@ -93,7 +93,7 @@ set(TrioBcftoolsXLinked-STDOUT
   "\r?\n#CHROM[^\r\n]*\r?\n[^\r\n]*\r?\n$"
 )
 
-set(TrioBcftoolsYLinked-CMD @DNG_CALL_EXE@ -m 0 -M ylinked -p ped/trio.ped bcftools/trio.call.vcf)
+set(TrioBcftoolsYLinked-CMD "@DNG_CALL_EXE@" -m 0 -M ylinked -p ped/trio.ped bcftools/trio.call.vcf)
 set(TrioBcftoolsYLinked-WD "@TESTDATA_DIR@/human_trio")
 set(TrioBcftoolsYLinked-RESULT 0)
 set(TrioBcftoolsYLinked-STDOUT
@@ -126,7 +126,7 @@ set(TrioBcftoolsYLinked-STDOUT-FAIL
 ###############################################################################
 # Test if dng-call supports regions
 
-set(TrioRegion-CMD @DNG_CALL_EXE@ -p ped/trio.ped -m 0 -r 5:126385921-126385925 bcftools/trio.mpileup.vcf.gz)
+set(TrioRegion-CMD "@DNG_CALL_EXE@" -p ped/trio.ped -m 0 -r 5:126385921-126385925 bcftools/trio.mpileup.vcf.gz)
 set(TrioRegion-WD "@TESTDATA_DIR@/human_trio")
 set(TrioRegion-RESULT 0)
 set(TrioRegion-STDOUT
@@ -145,7 +145,7 @@ set(TrioRegion-STDOUT-FAIL
 ###############################################################################
 # Test if dng-call ignores samples
 
-set(TrioExtraSample-CMD @DNG_CALL_EXE@ -p ped/trio.ped vcf/extra_sample.vcf)
+set(TrioExtraSample-CMD "@DNG_CALL_EXE@" -p ped/trio.ped vcf/extra_sample.vcf)
 set(TrioExtraSample-WD "@TESTDATA_DIR@/human_trio")
 set(TrioExtraSample-RESULT 0)
 set(TrioExtraSample-STDOUT
@@ -158,7 +158,7 @@ set(TrioExtraSample-FAIL
 ###############################################################################
 # Test how dng-call handles missing data
 
-set(MissingData-CMD @DNG_CALL_EXE@ -m 0 --ped trio.ped trio_missing.vcf)
+set(MissingData-CMD "@DNG_CALL_EXE@" -m 0 --ped trio.ped trio_missing.vcf)
 set(MissingData-WD "@TESTDATA_DIR@/vcf_missing_data/")
 set(MissingData-RESULT 0)
 set(MissingData-STDOUT
@@ -178,7 +178,7 @@ set(MissingData-STDOUT
 ###############################################################################
 # Test if dng-call works on a pipe
 
-set(PipedTrio-CMD sh -c "cat bcftools/trio.mpileup.vcf | @DNG_CALL_EXE@ -p ped/trio.ped vcf:-")
+set(PipedTrio-CMD sh -c "cat bcftools/trio.mpileup.vcf | '@DNG_CALL_EXE@' -p ped/trio.ped vcf:-")
 set(PipedTrio-WD ${TrioMpileup-WD})
 set(PipedTrio-RESULT ${TrioMpileup-RESULT})
 set(PipedTrio-STDOUT ${TrioMpileup-STDOUT})
@@ -186,17 +186,17 @@ set(PipedTrio-STDOUT ${TrioMpileup-STDOUT})
 ###############################################################################
 # Test if dng-call can output specific file types
 
-set(OutputVcf-CMD sh -c "@DNG_CALL_EXE@ -p ped/trio.ped -o vcf:- bcftools/trio.call.vcf | htsfile -")
+set(OutputVcf-CMD sh -c "'@DNG_CALL_EXE@' -p ped/trio.ped -o vcf:- bcftools/trio.call.vcf | htsfile -")
 set(OutputVcf-WD ${TrioMpileup-WD})
 set(OutputVcf-RESULT 0)
 set(OutputVcf-STDOUT "^-:\tVCF version [0-9.]+ variant calling text\r?\n$")
 
-set(OutputVcfGz-CMD sh -c "@DNG_CALL_EXE@ -p ped/trio.ped -o vcf.gz:- bcftools/trio.call.vcf | htsfile -")
+set(OutputVcfGz-CMD sh -c "'@DNG_CALL_EXE@' -p ped/trio.ped -o vcf.gz:- bcftools/trio.call.vcf | htsfile -")
 set(OutputVcfGz-WD ${TrioMpileup-WD})
 set(OutputVcfGz-RESULT 0)
 set(OutputVcfGz-STDOUT "^-:\tVCF version [0-9.]+ BGZF-compressed variant calling data\r?\n$")
 
-set(OutputBcf-CMD sh -c "@DNG_CALL_EXE@ -p ped/trio.ped -o bcf:- bcftools/trio.call.vcf | htsfile -")
+set(OutputBcf-CMD sh -c "'@DNG_CALL_EXE@' -p ped/trio.ped -o bcf:- bcftools/trio.call.vcf | htsfile -")
 set(OutputBcf-WD ${TrioMpileup-WD})
 set(OutputBcf-RESULT 0)
 set(OutputBcf-STDOUT "^-:\tBCF version [0-9.]+ compressed variant calling data\r?\n$")

--- a/Tests/DngDnm/AutoTest.cmake.in
+++ b/Tests/DngDnm/AutoTest.cmake.in
@@ -1,4 +1,4 @@
-set(TrioVcf-CMD @DNG_DNM_EXE@ auto --ped sample_CEU.ped --vcf sample_CEU.vcf --snp_mrate 2e-10 --indel_mrate 0.001)
+set(TrioVcf-CMD "@DNG_DNM_EXE@" auto --ped sample_CEU.ped --vcf sample_CEU.vcf --snp_mrate 2e-10 --indel_mrate 0.001)
 set(TrioVcf-WD "@TESTDATA_DIR@/sample_CEU/")
 set(TrioVcf-RESULT 0)
 set(TrioVcf-STDOUT
@@ -25,7 +25,7 @@ set(TrioVcf-STDOUT
   "maxlike_null: 1.51281[0-9]*e-26 pp_null: 3.16414[0-9]*e-14"
 )
 
-set(TrioBcf-CMD @DNG_DNM_EXE@ auto --ped sample_CEU.ped --bcf sample_CEU.bcf --snp_mrate 2e-10 --indel_mrate 0.001)
+set(TrioBcf-CMD "@DNG_DNM_EXE@" auto --ped sample_CEU.ped --bcf sample_CEU.bcf --snp_mrate 2e-10 --indel_mrate 0.001)
 set(TrioBcf-WD "@TESTDATA_DIR@/sample_CEU/")
 set(TrioBcf-RESULT 0)
 set(TrioBcf-STDOUT
@@ -48,7 +48,7 @@ set(TrioBcf-STDOUT
   "MAPPING_QUALITY child: 59 dad: 59 mom: 59"
 )
 
-set(PairVcf-CMD @DNG_DNM_EXE@ auto --ped sample_paired.ped --vcf sample_CEU.vcf)
+set(PairVcf-CMD "@DNG_DNM_EXE@" auto --ped sample_paired.ped --vcf sample_CEU.vcf)
 set(PairVcf-WD "@TESTDATA_DIR@/sample_CEU/")
 set(PairVcf-RESULT 0)
 set(PairVcf-STDOUT
@@ -72,7 +72,7 @@ set(PairVcf-STDOUT
   "dnm_snpcode: 2"
 )
 
-set(TrioAT-CMD @DNG_DNM_EXE@ auto --ped mutationAT.ped --vcf mutationAT.vcf --snp_mrate 1e-8 --poly_rate 0.001)
+set(TrioAT-CMD "@DNG_DNM_EXE@" auto --ped mutationAT.ped --vcf mutationAT.vcf --snp_mrate 1e-8 --poly_rate 0.001)
 set(TrioAT-WD "@TESTDATA_DIR@/trio/")
 set(TrioAT-RESULT 0)
 set(TrioAT-STDOUT
@@ -90,7 +90,7 @@ set(TrioAT-STDOUT
   "flag: 0"
 )
 
-set(TrioFloat-CMD @DNG_DNM_EXE@ auto auto --ped sample_CEU.ped --bcf sample_CEU_float.vcf --snp_mrate 2e-10 --indel_mrate 0.001)
+set(TrioFloat-CMD "@DNG_DNM_EXE@" auto auto --ped sample_CEU.ped --bcf sample_CEU_float.vcf --snp_mrate 2e-10 --indel_mrate 0.001)
 set(TrioFloat-WD "@TESTDATA_DIR@/sample_CEU/")
 set(TrioFloat-RESULT 0)
 set(TrioFloat-STDOUT
@@ -98,7 +98,7 @@ set(TrioFloat-STDOUT
 )
 
 
-set(MultiTrios-CMD @DNG_DNM_EXE@ auto auto --ped multi_trio.ped --bcf sample_CEU_mulit.vcf --write "-")
+set(MultiTrios-CMD "@DNG_DNM_EXE@" auto auto --ped multi_trio.ped --bcf sample_CEU_mulit.vcf --write "-")
 set(MultiTrios-WD "@TESTDATA_DIR@/sample_CEU/")
 set(MultiTrios-RESULT 0)
 set(MultiTrios-STDOUT
@@ -108,7 +108,7 @@ set(MultiTrios-STDOUT
   "\\.:\\.:\\.:\\.:\\.:\\.	DD/RD/RD:1\\.62015e-05:DD/RR/RR:0\\.999984:46:59"
 )
 
-set(MixedTrios-CMD @DNG_DNM_EXE@ auto auto --ped multi_trio_mixed.ped --bcf sample_mixed_trios.vcf --write "-")
+set(MixedTrios-CMD "@DNG_DNM_EXE@" auto auto --ped multi_trio_mixed.ped --bcf sample_mixed_trios.vcf --write "-")
 set(MixedTrios-WD "@TESTDATA_DIR@/sample_CEU/")
 set(MixedTrios-RESULT 0)
 set(MixedTrios-STDOUT

--- a/Tests/DngDnm/RunTest.cmake.in
+++ b/Tests/DngDnm/RunTest.cmake.in
@@ -1,9 +1,9 @@
-set(Help-CMD @DNG_DNM_EXE@ --help)
+set(Help-CMD "@DNG_DNM_EXE@" --help)
 set(Help-WD ".")
 set(Help-RESULT 0)
 set(Help-STDERR "Usage:\nAutosomes:\n\tdng dnm")
 
-set(InputErr-CMD @DNG_DNM_EXE@ auto)
+set(InputErr-CMD "@DNG_DNM_EXE@" auto)
 set(InputErr-WD ".")
 set(InputErr-RESULT 1)
 set(InputErr-STDERR "ERROR !")

--- a/Tests/DngLoglike/BamTest.cmake.in
+++ b/Tests/DngLoglike/BamTest.cmake.in
@@ -1,7 +1,7 @@
 ###############################################################################
 # Test dng-loglike functioning with bam file
 
-set(BasicTest-CMD @DNG_LOGLIKE_EXE@ -p ped/trio.ped -f trio.fasta.gz trio.bam)
+set(BasicTest-CMD "@DNG_LOGLIKE_EXE@" -p ped/trio.ped -f trio.fasta.gz trio.bam)
 set(BasicTest-WD "@TESTDATA_DIR@/human_trio")
 set(BasicTest-Result 0)
 set(BasicTest-STDOUT
@@ -12,7 +12,7 @@ set(BasicTest-STDOUT
 
 ###############################################################################
 # Test if dng-loglike crashes on missing bam
-set(EmptyBam-CMD @DNG_LOGLIKE_EXE@ -p ped/trio.ped -f trio.fasta.gz empty.bam)
+set(EmptyBam-CMD "@DNG_LOGLIKE_EXE@" -p ped/trio.ped -f trio.fasta.gz empty.bam)
 set(EmptyBam-WD "@TESTDATA_DIR@/human_trio")
 set(EmptyBam-Result 1)
 set(EmptyBam-STDERR
@@ -21,7 +21,7 @@ set(EmptyBam-STDERR
 
 ###############################################################################
 # Test if dng-loglike crashes on more than one input type file
-set(MultiInput-CMD @DNG_LOGLIKE_EXE@ -p ped/trio.ped -f trio.fasta.gz trio.bam test1.vcf)
+set(MultiInput-CMD "@DNG_LOGLIKE_EXE@" -p ped/trio.ped -f trio.fasta.gz trio.bam test1.vcf)
 set(MultiInput-WD "@TESTDATA_DIR@/human_trio")
 set(MultiInput-Result 1)
 set(MultiInput-STDERR
@@ -30,7 +30,7 @@ set(MultiInput-STDERR
 
 ###############################################################################
 # Test if dng-loglike crashes if fasta file is not specified
-set(NoFasta-CMD @DNG_LOGLIKE_EXE@ -p ped/trio.ped trio.bam)
+set(NoFasta-CMD "@DNG_LOGLIKE_EXE@" -p ped/trio.ped trio.bam)
 set(NoFasta-WD "@TESTDATA_DIR@/human_trio")
 set(NoFasta-Result 1)
 set(NoFasta-STDERR
@@ -39,7 +39,7 @@ set(NoFasta-STDERR
 
 ###############################################################################
 # Test if dng-loglike crashes on unknown --region file
-set(Region-CMD @DNG_LOGLIKE_EXE@ --region A -p ped/trio.ped -f trio.fasta.gz trio.bam)
+set(Region-CMD "@DNG_LOGLIKE_EXE@" --region A -p ped/trio.ped -f trio.fasta.gz trio.bam)
 set(Region-WD "@TESTDATA_DIR@/human_trio")
 set(Region-Result 1)
 set(Region-STDERR
@@ -48,7 +48,7 @@ set(Region-STDERR
 
 ###############################################################################
 # Test if dng-loglike works on a pipe
-set(PipedTrio-CMD sh -c "cat trio.bam | @DNG_LOGLIKE_EXE@ -p ped/trio.ped -f trio.fasta.gz bam:-")
+set(PipedTrio-CMD sh -c "cat trio.bam | '@DNG_LOGLIKE_EXE@' -p ped/trio.ped -f trio.fasta.gz bam:-")
 set(PipedTrio-WD ${BasicTest-WD})
 set(PipedTrio-RESULT ${BasicTest-RESULT})
 set(PipedTrio-STDOUT ${BasicTest-STDOUT})

--- a/Tests/DngLoglike/CramTest.cmake.in
+++ b/Tests/DngLoglike/CramTest.cmake.in
@@ -1,7 +1,7 @@
 ###############################################################################
 # Test dng-loglike functioning with bam file
 
-set(BasicTest-CMD @DNG_LOGLIKE_EXE@ -p ped/trio.ped -f trio.fasta.gz trio.cram)
+set(BasicTest-CMD "@DNG_LOGLIKE_EXE@" -p ped/trio.ped -f trio.fasta.gz trio.cram)
 set(BasicTest-WD "@TESTDATA_DIR@/human_trio")
 set(BasicTest-Result 0)
 set(BasicTest-STDOUT
@@ -12,7 +12,7 @@ set(BasicTest-STDOUT
 
 ###############################################################################
 # Test if dng-loglike crashes on missing bam
-set(EmptyCram-CMD @DNG_LOGLIKE_EXE@ -p ped/trio.ped -f trio.fasta.gz empty.cram)
+set(EmptyCram-CMD "@DNG_LOGLIKE_EXE@" -p ped/trio.ped -f trio.fasta.gz empty.cram)
 set(EmptyCram-WD "@TESTDATA_DIR@/human_trio")
 set(EmptyCram-Result 1)
 set(EmptyCram-STDERR
@@ -21,7 +21,7 @@ set(EmptyCram-STDERR
 
 ###############################################################################
 # Test if dng-loglike crashes on more than one input type file
-set(MultiInput-CMD @DNG_LOGLIKE_EXE@ -p ped/trio.ped -f trio.fasta.gz trio.cram test1.vcf)
+set(MultiInput-CMD "@DNG_LOGLIKE_EXE@" -p ped/trio.ped -f trio.fasta.gz trio.cram test1.vcf)
 set(MultiInput-WD "@TESTDATA_DIR@/human_trio")
 set(MultiInput-Result 1)
 set(MultiInput-STDERR
@@ -30,7 +30,7 @@ set(MultiInput-STDERR
 
 ###############################################################################
 # Test if dng-loglike crashes if fasta file is not specified
-set(NoFasta-CMD @DNG_LOGLIKE_EXE@ -p ped/trio.ped trio.cram)
+set(NoFasta-CMD "@DNG_LOGLIKE_EXE@" -p ped/trio.ped trio.cram)
 set(NoFasta-WD "@TESTDATA_DIR@/human_trio")
 set(NoFasta-Result 1)
 set(NoFasta-STDERR
@@ -39,7 +39,7 @@ set(NoFasta-STDERR
 
 ###############################################################################
 # Test if dng-loglike crashes on unknown --region file
-set(Region-CMD @DNG_LOGLIKE_EXE@ --region A -p ped/trio.ped -f trio.fasta.gz trio.cram)
+set(Region-CMD "@DNG_LOGLIKE_EXE@" --region A -p ped/trio.ped -f trio.fasta.gz trio.cram)
 set(Region-WD "@TESTDATA_DIR@/human_trio")
 set(Region-Result 1)
 set(Region-STDERR
@@ -48,7 +48,7 @@ set(Region-STDERR
 
 ###############################################################################
 # Test if dng-loglike works on a pipe
-set(PipedTrio-CMD sh -c "cat trio.cram | @DNG_LOGLIKE_EXE@ -p ped/trio.ped -f trio.fasta.gz cram:-")
+set(PipedTrio-CMD sh -c "cat trio.cram | '@DNG_LOGLIKE_EXE@' -p ped/trio.ped -f trio.fasta.gz cram:-")
 set(PipedTrio-WD ${BasicTest-WD})
 set(PipedTrio-RESULT ${BasicTest-RESULT})
 set(PipedTrio-STDOUT ${BasicTest-STDOUT})

--- a/Tests/DngLoglike/RunTest.cmake.in
+++ b/Tests/DngLoglike/RunTest.cmake.in
@@ -1,4 +1,4 @@
-set(Help-CMD @DNG_LOGLIKE_EXE@ --help)
+set(Help-CMD "@DNG_LOGLIKE_EXE@" --help)
 set(Help-WD ".")
 set(Help-RESULT 0)
 set(Help-STDERR "Usage:\n  dng loglike")

--- a/Tests/DngLoglike/VcfTest.cmake.in
+++ b/Tests/DngLoglike/VcfTest.cmake.in
@@ -1,7 +1,7 @@
 ###############################################################################
 # Test dng-loglike functioning with vcf file
 
-set(BasicTest-CMD @DNG_LOGLIKE_EXE@ -p ped/trio.ped bcftools/trio.mpileup.vcf)
+set(BasicTest-CMD "@DNG_LOGLIKE_EXE@" -p ped/trio.ped bcftools/trio.mpileup.vcf)
 set(BasicTest-WD "@TESTDATA_DIR@/human_trio")
 set(BasicTest-Result 0)
 set(BasicTest-STDOUT
@@ -12,7 +12,7 @@ set(BasicTest-STDOUT
 
 ###############################################################################
 # Test if dng-loglike fails on missing vcf 
-set(EmptyVcf-CMD @DNG_LOGLIKE_EXE@ -p ped/trio.ped -f trio.fasta.gz empty.vcf)
+set(EmptyVcf-CMD "@DNG_LOGLIKE_EXE@" -p ped/trio.ped -f trio.fasta.gz empty.vcf)
 set(EmptyVcf-WD "@TESTDATA_DIR@/human_trio")
 set(EmptyVcf-Result 1)
 set(EmptyVcf-STDERR
@@ -21,7 +21,7 @@ set(EmptyVcf-STDERR
 
 ###############################################################################
 # Test if dng-loglike crashes on more than one input file
-set(MultiInput-CMD @DNG_LOGLIKE_EXE@ -p ped/trio.ped -f trio.fasta.gz test1.vcf test1.vcf)
+set(MultiInput-CMD "@DNG_LOGLIKE_EXE@" -p ped/trio.ped -f trio.fasta.gz test1.vcf test1.vcf)
 set(MultiInput-WD "@TESTDATA_DIR@/human_trio")
 set(MultiInput-Result 1)
 set(MultiInput-STDERR
@@ -30,7 +30,7 @@ set(MultiInput-STDERR
 
 ###############################################################################
 # Test if dng-loglike works on a pipe
-set(PipedTrio-CMD sh -c "cat bcftools/trio.mpileup.vcf | @DNG_LOGLIKE_EXE@ -p ped/trio.ped vcf:-")
+set(PipedTrio-CMD sh -c "cat bcftools/trio.mpileup.vcf | '@DNG_LOGLIKE_EXE@' -p ped/trio.ped vcf:-")
 set(PipedTrio-WD ${BasicTest-WD})
 set(PipedTrio-RESULT ${BasicTest-RESULT})
 set(PipedTrio-STDOUT ${BasicTest-STDOUT})

--- a/Tests/DngPhaser/DataTest.cmake.in
+++ b/Tests/DngPhaser/DataTest.cmake.in
@@ -1,4 +1,4 @@
-set(Data-CMD @DNG_PHASER_EXE@ --dnm sample_phasing_dnm_f --pgt sample_phasing_GTs_f --bam test1.bam)
+set(Data-CMD "@DNG_PHASER_EXE@" --dnm sample_phasing_dnm_f --pgt sample_phasing_GTs_f --bam test1.bam)
 set(Data-WD "@TESTDATA_DIR@/sample_Phaser/")
 set(Data-RESULT 0)
 set(Data-STDOUT

--- a/Tests/DngPhaser/RunTest.cmake.in
+++ b/Tests/DngPhaser/RunTest.cmake.in
@@ -1,9 +1,9 @@
-set(Help-CMD @DNG_PHASER_EXE@ --help)
+set(Help-CMD "@DNG_PHASER_EXE@" --help)
 set(Help-WD ".")
 set(Help-RESULT 0)
 set(Help-STDERR "Usage:\n  dng phaser")
 
-set(InputErr-CMD @DNG_PHASER_EXE@)
+set(InputErr-CMD "@DNG_PHASER_EXE@")
 set(InputErr-WD ".")
 set(InputErr-RESULT 1)
 set(InputErr-STDERR "INPUT ERROR!")


### PR DESCRIPTION
Add quotation marks to exe variables on integration tests so if folder's name has spaces integration tests still succeed