### PR TITLE
fixed comparison error

### DIFF
--- a/src/contrib/newmat/newmat6.cpp
+++ b/src/contrib/newmat/newmat6.cpp
@@ -428,7 +428,7 @@ void CroutMatrix::operator=(const CroutMatrix& gm)
 {
    if (&gm == this) { REPORT tag_val = -1; return; }
    REPORT
-   if (indx > 0) { delete [] indx; indx = 0; }
+   if (indx != NULL) { delete [] indx; indx = 0; }
    ((CroutMatrix&)gm).get_aux(*this);
    Eq(gm);
 }


### PR DESCRIPTION
Hello.I found an error building `denovogear`, so I suggest sourse fixes.
Could you check if it is the right fix?

- error
```
  >> 162    newmat6.cpp:431:13: error: ordered comparison between pointer and z
            ero ('int *' and 'int')                                            
     163       if (indx > 0) { delete [] indx; indx = 0; }
     164           ~~~~ ^ ~
```
I changed comparison from `indx > 0` to `indx != NULL`